### PR TITLE
fix: add eval timeout handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1124,7 +1124,7 @@ class GodotServer {
             required: [],
           },
         },
-{
+        {
           name: 'game_eval',
           description: 'Execute GDScript in the running game. Use "return" for values.',
           inputSchema: {
@@ -1133,6 +1133,10 @@ class GodotServer {
               code: {
                 type: 'string',
                 description: 'GDScript code to execute. Use "return" to return values.',
+              },
+              timeoutSeconds: {
+                type: 'number',
+                description: 'Optional execution timeout in seconds. Clamped below the server busy timeout.',
               },
             },
             required: ['code'],
@@ -4518,7 +4522,16 @@ class GodotServer {
   private async handleGameEval(args: any) {
     args = normalizeParameters(args || {});
     if (!args.code) return createErrorResponse('code parameter is required.');
-    return this.gameCommand('eval', args, a => ({ code: a.code }), 30000);
+    const timeoutSeconds = args.timeoutSeconds !== undefined ? Number(args.timeoutSeconds) : 28;
+    if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) {
+      return createErrorResponse('timeoutSeconds must be a positive number.');
+    }
+    const clampedTimeoutSeconds = Math.min(timeoutSeconds, 29);
+    const timeoutMs = Math.ceil(clampedTimeoutSeconds * 1000) + 2000;
+    return this.gameCommand('eval', args, a => ({
+      code: a.code,
+      timeout_seconds: clampedTimeoutSeconds,
+    }), timeoutMs);
   }
 
   private async handleGameGetProperty(args: any) {

--- a/src/scripts/mcp_interaction_server.gd
+++ b/src/scripts/mcp_interaction_server.gd
@@ -543,13 +543,23 @@ func _cmd_eval(params: Dictionary) -> void:
 	if code.is_empty():
 		_send_response({"error": "No code provided"})
 		return
+	var timeout_seconds: float = clampf(float(params.get("timeout_seconds", BUSY_TIMEOUT - 2.0)), 0.1, BUSY_TIMEOUT - 1.0)
 
 	# Wrap user code in a function so we can capture the return value
 	var script_source: String = """extends Node
 
-func execute():
+func execute(timeout_seconds: float):
 	var __result = null
-	__result = await _run()
+	var __finished := false
+	var __runner := func():
+		__result = await _run()
+		__finished = true
+	__runner.call_deferred()
+	var __deadline := Time.get_ticks_msec() / 1000.0 + timeout_seconds
+	while not __finished and Time.get_ticks_msec() / 1000.0 < __deadline:
+		await get_tree().process_frame
+	if not __finished:
+		return {"__eval_timed_out": true}
 	return __result
 
 func _run():
@@ -571,9 +581,12 @@ func _run():
 
 	var result: Variant = null
 	if temp_node.has_method("execute"):
-		result = await temp_node.execute()
+		result = await temp_node.execute(timeout_seconds)
 
 	temp_node.queue_free()
+	if result is Dictionary and result.get("__eval_timed_out", false):
+		_send_response({"error": "Eval execution timed out after %.1fs" % timeout_seconds})
+		return
 	_send_response({"success": true, "result": _variant_to_json(result)})
 
 

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -128,10 +128,20 @@ describe('Game command handlers — argument transforms', () => {
 
   // game_eval
   describe('handleGameEval', () => {
-    it('passes code parameter', () => {
+    it('passes code parameter with default timeout', () => {
       const args = normalizeParameters({ code: 'get_tree().root.name' });
-      const r = fakeGameCommand(true, true, args, a => ({ code: a.code }));
-      expect(r.commandArgs).toEqual({ code: 'get_tree().root.name' });
+      const timeoutSeconds = args.timeoutSeconds !== undefined ? Number(args.timeoutSeconds) : 28;
+      const clampedTimeoutSeconds = Math.min(timeoutSeconds, 29);
+      const r = fakeGameCommand(true, true, args, a => ({ code: a.code, timeout_seconds: clampedTimeoutSeconds }));
+      expect(r.commandArgs).toEqual({ code: 'get_tree().root.name', timeout_seconds: 28 });
+    });
+
+    it('passes custom timeoutSeconds to runtime timeout_seconds', () => {
+      const args = normalizeParameters({ code: 'return 1', timeoutSeconds: 12 });
+      const timeoutSeconds = args.timeoutSeconds !== undefined ? Number(args.timeoutSeconds) : 28;
+      const clampedTimeoutSeconds = Math.min(timeoutSeconds, 29);
+      const r = fakeGameCommand(true, true, args, a => ({ code: a.code, timeout_seconds: clampedTimeoutSeconds }));
+      expect(r.commandArgs).toEqual({ code: 'return 1', timeout_seconds: 12 });
     });
   });
 


### PR DESCRIPTION
## Summary
- add runtime-side timeout handling for game_eval so long-running evals return a clear error instead of leaving the eval node hanging
- expose an optional 	imeoutSeconds parameter in the MCP tool and forward it to Godot while keeping the client wait slightly longer than the runtime timeout
- cover the new timeout mapping in handler tests

## Verification
- npm test
- npm run build