### PR TITLE
Add tool filtering, C# script support, and fix some WSL/Windows issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,14 @@ The server listens on `127.0.0.1:9090` and accepts JSON commands over TCP when t
 |----------|-------------|
 | `GODOT_PATH` | Path to the Godot executable (overrides auto-detection) |
 | `DEBUG` | Set to `"true"` for detailed server-side logging |
+
+### WSL + Windows Godot
+
+The server runs under Linux Node (WSL) but accepts Windows-style project paths
+(`C:/foo/bar`, `C:\foo\bar`) and translates them to `/mnt/c/foo/bar` for
+filesystem checks. When `GODOT_PATH` points at a Windows `.exe`, the inverse
+translation is applied when invoking the binary so it receives a path it can
+open.
 | `GODOT_MCP_CONFIG` | Path to a JSON tool-filter config file (see "Tool Filtering") |
 | `GODOT_MCP_ENABLED_TOOLS` | Comma-separated allowlist of tool names |
 | `GODOT_MCP_DISABLED_TOOLS` | Comma-separated denylist of tool names |

--- a/README.md
+++ b/README.md
@@ -540,13 +540,11 @@ The server listens on `127.0.0.1:9090` and accepts JSON commands over TCP when t
 
 ## Tool Filtering
 
-The server exposes ~150 tools by default. Operators can narrow the surface via
-environment variables or a JSON config file — useful for pure-C# projects that
-want to strip GDScript-only tools, or for agents that only need a subset.
+Restrict the exposed tool set via env vars or a JSON config.
 
-### JSON config file
+### Config file
 
-Point `GODOT_MCP_CONFIG` at a JSON file:
+`GODOT_MCP_CONFIG` points at a JSON file. All fields optional.
 
 ```json
 {
@@ -557,93 +555,59 @@ Point `GODOT_MCP_CONFIG` at a JSON file:
 }
 ```
 
-All four fields are optional. An absent field means "no filter on that axis".
+### Env vars
 
-### Environment-variable overrides
+`GODOT_MCP_ENABLED_TOOLS`, `GODOT_MCP_DISABLED_TOOLS`, `GODOT_MCP_ENABLED_TAGS`,
+`GODOT_MCP_DISABLED_TAGS` take comma-separated lists. Each env var replaces the
+corresponding JSON field (per-field, not merged).
 
-Any of `GODOT_MCP_ENABLED_TOOLS`, `GODOT_MCP_DISABLED_TOOLS`,
-`GODOT_MCP_ENABLED_TAGS`, `GODOT_MCP_DISABLED_TAGS` accepts a comma-separated
-list. When set, each env var **replaces the corresponding field** from the JSON
-file (per-field, not merged).
+### Filter rules
 
-### Filter semantics
+A tool passes when: it's in `enabledTools` (if set), it's not in
+`disabledTools`, at least one of its tags is in `enabledTags` (if set), and
+none of its tags are in `disabledTags`. Denylists win ties.
 
-A tool is exposed when all of these hold:
+Disabled tools return `MethodNotFound` and don't appear in `tools/list`.
 
-1. If `enabledTools` is set, the tool's name is in the list.
-2. The tool's name is not in `disabledTools`.
-3. If `enabledTags` is set, the tool has at least one tag from the list.
-4. None of the tool's tags appear in `disabledTags`.
+### Tags
 
-Denylist rules win over allowlist rules when both match.
-
-### Tag taxonomy
-
-Tools are tagged so filters can target whole subsystems. Most tools carry 1–3
-tags; a tool may appear under several categories (e.g. `game_physics_2d` is
-`runtime` + `2d` + `physics`).
-
-| Tag | What it covers |
-|-----|----------------|
-| `runtime` | Requires a running game connected over the TCP interaction server |
-| `headless` | Works without a running game (CLI/file-system operations) |
-| `editor` | Editor lifecycle (launch, version, run/stop) |
-| `project` | `project.godot`, autoloads, input map, export presets, plugins, layers, translations, CI/CD |
-| `scene` | `.tscn` reads/writes, node structure, scene changes, instancing |
-| `script` | Script attach/detach/create |
-| `gdscript-only` | Requires GDScript — strip these for pure-C# projects |
-| `file-io` | Raw file and directory ops |
-| `2d` | 2D-specific (tilemap, canvas, parallax, `Light2D`, `Shape2D`, `Path2D`) |
-| `3d` | 3D-specific (mesh, CSG, gridmap, `Light3D`, sky, navigation 3D, camera attributes) |
-| `physics` | Bodies, joints, raycasts, collision, 2D/3D physics |
-| `rendering` | Environment, viewport, debug draw, render settings, lights |
-| `shader` | Shader params, visual shader, shader resource management |
-| `animation` | Players, tweens, tree, particles, bone/skeleton |
+| Tag | Covers |
+|-----|--------|
+| `runtime` | Requires running game (TCP) |
+| `headless` | Works without running game |
+| `editor` | Launch, version, run/stop |
+| `project` | `project.godot`, autoloads, input map, exports, plugins, translations, CI |
+| `scene` | `.tscn` read/write, node structure, scene changes |
+| `script` | Attach/detach/create scripts |
+| `gdscript-only` | GDScript-only (currently just `game_eval`) |
+| `file-io` | File/directory ops |
+| `2d` | Tilemap, canvas, parallax, Light2D, Shape2D, Path2D |
+| `3d` | Mesh, CSG, gridmap, Light3D, sky, nav3D, camera attrs |
+| `physics` | Bodies, joints, raycasts, collision |
+| `rendering` | Environment, viewport, debug draw, lights |
+| `shader` | Shader params, visual shader |
+| `animation` | Players, tweens, tree, particles, bones |
 | `audio` | Buses, effects, playback, 3D audio |
-| `ui` | Control, text, popup, tree, item list, tabs, menu, range, theme |
-| `input` | Keyboard, mouse, gamepad, touch, input map/state/action |
-| `signal` | Connect/disconnect/emit/list/await signals |
+| `ui` | Control, text, popup, tree, tabs, menu, theme |
+| `input` | Keyboard, mouse, gamepad, touch, input map |
+| `signal` | Connect/disconnect/emit/list/await |
 | `networking` | HTTP, WebSocket, multiplayer, RPC |
 
-### Preset: pure-C# project
+### Presets
 
-To strip the GDScript-only tools (`game_eval`, `create_script`, `attach_script`,
-`game_script`) from a C# Godot project:
-
-```json
-{
-  "env": {
-    "GODOT_MCP_DISABLED_TAGS": "gdscript-only"
-  }
-}
-```
-
-### Preset: 2D-only project
-
-Drop every tool specific to 3D rendering/physics/navigation/audio:
+`create_script`, `attach_script`, and `game_script` accept `.cs` out of the
+box. Only `game_eval` is `gdscript-only` (runtime C# compile isn't supported).
 
 ```json
-{
-  "env": {
-    "GODOT_MCP_DISABLED_TAGS": "3d"
-  }
-}
+// Pure-C#: strip game_eval
+{ "env": { "GODOT_MCP_DISABLED_TAGS": "gdscript-only" } }
+
+// 2D-only
+{ "env": { "GODOT_MCP_DISABLED_TAGS": "3d" } }
+
+// Headless CI
+{ "env": { "GODOT_MCP_DISABLED_TAGS": "runtime" } }
 ```
-
-### Preset: headless automation / CI
-
-Keep only tools that don't need a running game:
-
-```json
-{
-  "env": {
-    "GODOT_MCP_DISABLED_TAGS": "runtime"
-  }
-}
-```
-
-Calling a disabled tool returns an MCP `MethodNotFound` error; it does not
-appear in `tools/list` responses.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -532,6 +532,118 @@ The server listens on `127.0.0.1:9090` and accepts JSON commands over TCP when t
 |----------|-------------|
 | `GODOT_PATH` | Path to the Godot executable (overrides auto-detection) |
 | `DEBUG` | Set to `"true"` for detailed server-side logging |
+| `GODOT_MCP_CONFIG` | Path to a JSON tool-filter config file (see "Tool Filtering") |
+| `GODOT_MCP_ENABLED_TOOLS` | Comma-separated allowlist of tool names |
+| `GODOT_MCP_DISABLED_TOOLS` | Comma-separated denylist of tool names |
+| `GODOT_MCP_ENABLED_TAGS` | Comma-separated allowlist of tool tags |
+| `GODOT_MCP_DISABLED_TAGS` | Comma-separated denylist of tool tags |
+
+## Tool Filtering
+
+The server exposes ~150 tools by default. Operators can narrow the surface via
+environment variables or a JSON config file — useful for pure-C# projects that
+want to strip GDScript-only tools, or for agents that only need a subset.
+
+### JSON config file
+
+Point `GODOT_MCP_CONFIG` at a JSON file:
+
+```json
+{
+  "enabledTools": ["launch_editor", "run_project"],
+  "disabledTools": ["game_eval"],
+  "enabledTags": ["scene"],
+  "disabledTags": ["gdscript-only"]
+}
+```
+
+All four fields are optional. An absent field means "no filter on that axis".
+
+### Environment-variable overrides
+
+Any of `GODOT_MCP_ENABLED_TOOLS`, `GODOT_MCP_DISABLED_TOOLS`,
+`GODOT_MCP_ENABLED_TAGS`, `GODOT_MCP_DISABLED_TAGS` accepts a comma-separated
+list. When set, each env var **replaces the corresponding field** from the JSON
+file (per-field, not merged).
+
+### Filter semantics
+
+A tool is exposed when all of these hold:
+
+1. If `enabledTools` is set, the tool's name is in the list.
+2. The tool's name is not in `disabledTools`.
+3. If `enabledTags` is set, the tool has at least one tag from the list.
+4. None of the tool's tags appear in `disabledTags`.
+
+Denylist rules win over allowlist rules when both match.
+
+### Tag taxonomy
+
+Tools are tagged so filters can target whole subsystems. Most tools carry 1–3
+tags; a tool may appear under several categories (e.g. `game_physics_2d` is
+`runtime` + `2d` + `physics`).
+
+| Tag | What it covers |
+|-----|----------------|
+| `runtime` | Requires a running game connected over the TCP interaction server |
+| `headless` | Works without a running game (CLI/file-system operations) |
+| `editor` | Editor lifecycle (launch, version, run/stop) |
+| `project` | `project.godot`, autoloads, input map, export presets, plugins, layers, translations, CI/CD |
+| `scene` | `.tscn` reads/writes, node structure, scene changes, instancing |
+| `script` | Script attach/detach/create |
+| `gdscript-only` | Requires GDScript — strip these for pure-C# projects |
+| `file-io` | Raw file and directory ops |
+| `2d` | 2D-specific (tilemap, canvas, parallax, `Light2D`, `Shape2D`, `Path2D`) |
+| `3d` | 3D-specific (mesh, CSG, gridmap, `Light3D`, sky, navigation 3D, camera attributes) |
+| `physics` | Bodies, joints, raycasts, collision, 2D/3D physics |
+| `rendering` | Environment, viewport, debug draw, render settings, lights |
+| `shader` | Shader params, visual shader, shader resource management |
+| `animation` | Players, tweens, tree, particles, bone/skeleton |
+| `audio` | Buses, effects, playback, 3D audio |
+| `ui` | Control, text, popup, tree, item list, tabs, menu, range, theme |
+| `input` | Keyboard, mouse, gamepad, touch, input map/state/action |
+| `signal` | Connect/disconnect/emit/list/await signals |
+| `networking` | HTTP, WebSocket, multiplayer, RPC |
+
+### Preset: pure-C# project
+
+To strip the GDScript-only tools (`game_eval`, `create_script`, `attach_script`,
+`game_script`) from a C# Godot project:
+
+```json
+{
+  "env": {
+    "GODOT_MCP_DISABLED_TAGS": "gdscript-only"
+  }
+}
+```
+
+### Preset: 2D-only project
+
+Drop every tool specific to 3D rendering/physics/navigation/audio:
+
+```json
+{
+  "env": {
+    "GODOT_MCP_DISABLED_TAGS": "3d"
+  }
+}
+```
+
+### Preset: headless automation / CI
+
+Keep only tools that don't need a running game:
+
+```json
+{
+  "env": {
+    "GODOT_MCP_DISABLED_TAGS": "runtime"
+  }
+}
+```
+
+Calling a disabled tool returns an MCP `MethodNotFound` error; it does not
+appear in `tools/list` responses.
 
 ## Architecture
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@modelcontextprotocol/sdk": "1.26.0",
         "axios": "^1.13.5",
         "fs-extra": "^11.2.0"
       },

--- a/spaceport-filter.json
+++ b/spaceport-filter.json
@@ -1,0 +1,14 @@
+{
+  "disabledTags": ["3d", "networking", "gdscript-only"],
+  "disabledTools": [
+    "create_project",
+    "list_projects",
+    "manage_docker_export",
+    "game_video",
+    "read_scene",
+    "game_serialize_state",
+    "export_project",
+    "manage_ci_pipeline",
+    "launch_editor"
+  ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1452,6 +1452,25 @@ class GodotServer {
           },
         },
         {
+          name: 'get_scene_warnings',
+          description: 'Collect per-node editor warnings for a scene file (headless).',
+          tags: ['scene', 'headless'],
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: {
+                type: 'string',
+                description: 'Godot project path',
+              },
+              scenePath: {
+                type: 'string',
+                description: 'Scene file path (relative to project)',
+              },
+            },
+            required: ['projectPath', 'scenePath'],
+          },
+        },
+        {
           name: 'modify_scene_node',
           description: 'Modify node properties in a scene file (headless)',
           tags: ['scene', 'headless'],
@@ -3532,6 +3551,8 @@ class GodotServer {
         // Headless scene tools
         case 'read_scene':
           return await this.handleReadScene(request.params.arguments);
+        case 'get_scene_warnings':
+          return await this.handleGetSceneWarnings(request.params.arguments);
         case 'modify_scene_node':
           return await this.handleModifySceneNode(request.params.arguments);
         case 'remove_scene_node':
@@ -5000,6 +5021,61 @@ class GodotServer {
       };
     } catch (error: any) {
       return createErrorResponse(`Failed to read scene: ${error?.message || 'Unknown error'}`);
+    }
+  }
+
+  /**
+   * Handle the get_scene_warnings tool - Collect editor configuration warnings per node
+   */
+  private async handleGetSceneWarnings(args: any) {
+    args = normalizeParameters(args || {});
+    if (!args.projectPath || !args.scenePath) {
+      return createErrorResponse('projectPath and scenePath are required.');
+    }
+
+    if (!validateProjectPath(args.projectPath) || !validatePath(args.scenePath)) {
+      return createErrorResponse('Invalid path.');
+    }
+
+    const projectFile = projectGodotFile(args.projectPath);
+    if (!existsSync(projectFile)) {
+      return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
+    }
+
+    const scenePath = projectFilePath(args.projectPath, args.scenePath);
+    if (!existsSync(scenePath)) {
+      return createErrorResponse(`Scene file does not exist: ${args.scenePath}`);
+    }
+
+    try {
+      const { stdout, stderr } = await this.executeOperation('get_scene_warnings', {
+        scenePath: args.scenePath,
+      }, args.projectPath);
+
+      const startMarker = 'WARNINGS_JSON_START';
+      const endMarker = 'WARNINGS_JSON_END';
+      const startIdx = stdout.indexOf(startMarker);
+      const endIdx = stdout.indexOf(endMarker);
+
+      if (startIdx !== -1 && endIdx !== -1) {
+        const jsonStr = stdout.substring(startIdx + startMarker.length, endIdx).trim();
+        try {
+          const parsed = JSON.parse(jsonStr);
+          return {
+            content: [{ type: 'text', text: JSON.stringify(parsed, null, 2) }],
+          };
+        } catch {
+          return {
+            content: [{ type: 'text', text: `Raw warnings data:\n${jsonStr}` }],
+          };
+        }
+      }
+
+      return {
+        content: [{ type: 'text', text: `get_scene_warnings output:\n${stdout}\n${stderr ? 'Errors:\n' + stderr : ''}` }],
+      };
+    } catch (error: any) {
+      return createErrorResponse(`Failed to collect scene warnings: ${error?.message || 'Unknown error'}`);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,10 @@ interface GodotProcess {
   process: any;
   output: string[];
   errors: string[];
+  // Windows-side PID when Godot.exe is invoked via WSL interop. The PID of
+  // `process` is a Linux-side relay — killing it does not reliably terminate
+  // the GUI Windows process, so we track the real PID separately for taskkill.
+  windowsPid?: number;
 }
 
 /**
@@ -489,7 +493,23 @@ class GodotServer {
           });
         });
 
-        // Successfully connected
+        // Successfully connected — handshake: ask the game to report its own
+        // PID so stop_project can taskkill exactly the right Windows process.
+        // Image-name matching is unsafe: the user's editor shares Godot.exe.
+        try {
+          const response = await this.sendGameCommand('get_pid', {}, 5000);
+          const reportedPid = Number(response?.pid);
+          if (Number.isFinite(reportedPid) && reportedPid > 0) {
+            if (this.activeProcess) {
+              this.activeProcess.windowsPid = reportedPid;
+              this.logDebug(`Game handshake reported Windows PID ${reportedPid}`);
+            }
+          } else {
+            this.logDebug(`Game handshake returned no usable PID: ${JSON.stringify(response)}`);
+          }
+        } catch (err) {
+          this.logDebug(`Game PID handshake failed: ${err instanceof Error ? err.message : err}`);
+        }
         return;
       } catch (err) {
         this.logDebug(`Connection attempt ${attempt}/${maxAttempts} failed, retrying in ${retryDelay}ms...`);
@@ -553,10 +573,50 @@ class GodotServer {
     }
     if (this.activeProcess) {
       this.logDebug('Killing active Godot process');
-      this.activeProcess.process.kill();
+      await this.killActiveProcess();
       this.activeProcess = null;
     }
     await this.server.close();
+  }
+
+  /**
+   * Terminate a specific Windows-side Godot PID via taskkill.exe. /T kills the
+   * process tree; /F forces it. Companion to the Node-side process.kill()
+   * because the WSL2 interop relay PID that Node holds is not the real Godot
+   * PID, so signalling the relay does not reliably terminate the GUI process.
+   */
+  private async killWindowsGodot(winPid: number): Promise<void> {
+    try {
+      await execFileAsync('taskkill.exe', ['/PID', String(winPid), '/T', '/F'], { timeout: 5000 });
+      this.logDebug(`taskkill succeeded for Windows PID ${winPid}`);
+    } catch (err) {
+      this.logDebug(`taskkill failed for PID ${winPid}: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  /**
+   * Kill the currently tracked Godot process. When we know the real Windows
+   * PID (from the game's handshake), taskkill.exe that PID so the GUI process
+   * actually dies. Then signal the Node-side relay so Node's own bookkeeping
+   * clears. Without a handshake PID we do NOT attempt any image-name-based
+   * discovery — that can match the user's long-running editor.
+   */
+  private async killActiveProcess(): Promise<void> {
+    if (!this.activeProcess) return;
+    const winPid = this.activeProcess.windowsPid;
+    if (winPid) {
+      await this.killWindowsGodot(winPid);
+    } else if (isWindowsGodotExe(this.godotPath) && process.platform === 'linux') {
+      this.logDebug(
+        'No handshake PID recorded for running game — cannot safely taskkill. ' +
+        'Falling back to relay-only kill; game may survive as orphan.'
+      );
+    }
+    try {
+      this.activeProcess.process.kill();
+    } catch (err) {
+      this.logDebug(`process.kill failed: ${err instanceof Error ? err.message : err}`);
+    }
   }
 
   private async gameCommand(
@@ -3825,7 +3885,8 @@ class GodotServer {
         if (this.gameConnection.projectPath) {
           this.removeInteractionServer(this.gameConnection.projectPath);
         }
-        this.activeProcess.process.kill();
+        await this.killActiveProcess();
+        this.activeProcess = null;
       }
 
       // Inject interaction server before launching
@@ -3879,7 +3940,10 @@ class GodotServer {
 
       this.activeProcess = { process, output, errors };
 
-      // Start async TCP connection to the interaction server (fire-and-forget)
+      // Start async TCP connection to the interaction server (fire-and-forget).
+      // The connection handshake also resolves the real Windows-side PID from
+      // the game itself (see connectToGame), which is what stop_project uses
+      // to taskkill the correct Godot.exe.
       this.connectToGame(args.projectPath).catch(err => {
         this.logDebug(`Failed to connect to game interaction server: ${err}`);
       });
@@ -3938,10 +4002,13 @@ class GodotServer {
     }
 
     this.logDebug('Stopping active Godot process');
-    this.disconnectFromGame();
-    this.activeProcess.process.kill();
+    // Capture windowsPid BEFORE disconnect — disconnect tears down the TCP
+    // socket; killActiveProcess needs the handshake PID to taskkill the right
+    // Godot.exe.
     const output = this.activeProcess.output;
     const errors = this.activeProcess.errors;
+    this.disconnectFromGame();
+    await this.killActiveProcess();
     this.activeProcess = null;
     this.lastErrorIndex = 0;
     this.lastLogIndex = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {
   normalizeParameters,
   convertCamelToSnakeCase,
   validatePath,
+  validateProjectPath,
   createErrorResponse,
   addGodotIniSectionLine,
   removeGodotIniSectionLine,
@@ -644,7 +645,7 @@ class GodotServer {
     const { projectPath, params } = argsFn(args);
 
     if (!projectPath) return createErrorResponse('projectPath is required.');
-    if (!validatePath(projectPath)) return createErrorResponse('Invalid path.');
+    if (!validateProjectPath(projectPath)) return createErrorResponse('Invalid path.');
 
     const projectFile = projectGodotFile(projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${projectPath}`);
@@ -3814,7 +3815,7 @@ class GodotServer {
       );
     }
 
-    if (!validatePath(args.projectPath)) {
+    if (!validateProjectPath(args.projectPath)) {
       return createErrorResponse(
         'Invalid project path'
       );
@@ -3873,7 +3874,7 @@ class GodotServer {
   private async handleBuildProject(args: any) {
     args = normalizeParameters(args);
     if (!args.projectPath) return createErrorResponse('Project path is required');
-    if (!validatePath(args.projectPath)) return createErrorResponse('Invalid project path');
+    if (!validateProjectPath(args.projectPath)) return createErrorResponse('Invalid project path');
 
     try {
       if (!this.godotPath) {
@@ -3938,7 +3939,7 @@ class GodotServer {
       );
     }
 
-    if (!validatePath(args.projectPath)) {
+    if (!validateProjectPath(args.projectPath)) {
       return createErrorResponse(
         'Invalid project path'
       );
@@ -4265,7 +4266,7 @@ class GodotServer {
       );
     }
   
-    if (!validatePath(args.projectPath)) {
+    if (!validateProjectPath(args.projectPath)) {
       return createErrorResponse(
         'Invalid project path'
       );
@@ -4350,7 +4351,7 @@ class GodotServer {
       );
     }
 
-    if (!validatePath(args.projectPath) || !validatePath(args.scenePath)) {
+    if (!validateProjectPath(args.projectPath) || !validatePath(args.scenePath)) {
       return createErrorResponse(
         'Invalid path'
       );
@@ -4408,7 +4409,7 @@ class GodotServer {
       );
     }
 
-    if (!validatePath(args.projectPath) || !validatePath(args.scenePath)) {
+    if (!validateProjectPath(args.projectPath) || !validatePath(args.scenePath)) {
       return createErrorResponse(
         'Invalid path'
       );
@@ -4485,7 +4486,7 @@ class GodotServer {
     }
 
     if (
-      !validatePath(args.projectPath) ||
+      !validateProjectPath(args.projectPath) ||
       !validatePath(args.scenePath) ||
       !validatePath(args.nodePath) ||
       !validatePath(args.texturePath)
@@ -4565,7 +4566,7 @@ class GodotServer {
     }
 
     if (
-      !validatePath(args.projectPath) ||
+      !validateProjectPath(args.projectPath) ||
       !validatePath(args.scenePath) ||
       !validatePath(args.outputPath)
     ) {
@@ -4639,7 +4640,7 @@ class GodotServer {
       );
     }
 
-    if (!validatePath(args.projectPath) || !validatePath(args.scenePath)) {
+    if (!validateProjectPath(args.projectPath) || !validatePath(args.scenePath)) {
       return createErrorResponse(
         'Invalid path'
       );
@@ -4742,7 +4743,7 @@ class GodotServer {
       );
     }
 
-    if (!validatePath(args.projectPath) || !validatePath(args.filePath)) {
+    if (!validateProjectPath(args.projectPath) || !validatePath(args.filePath)) {
       return createErrorResponse(
         'Invalid path'
       );
@@ -4955,7 +4956,7 @@ class GodotServer {
       return createErrorResponse('projectPath and scenePath are required.');
     }
 
-    if (!validatePath(args.projectPath) || !validatePath(args.scenePath)) {
+    if (!validateProjectPath(args.projectPath) || !validatePath(args.scenePath)) {
       return createErrorResponse('Invalid path.');
     }
 
@@ -5035,7 +5036,7 @@ class GodotServer {
       return createErrorResponse('projectPath is required.');
     }
 
-    if (!validatePath(args.projectPath)) {
+    if (!validateProjectPath(args.projectPath)) {
       return createErrorResponse('Invalid path.');
     }
 
@@ -5064,7 +5065,7 @@ class GodotServer {
       return createErrorResponse('projectPath, section, key, and value are required.');
     }
 
-    if (!validatePath(args.projectPath)) {
+    if (!validateProjectPath(args.projectPath)) {
       return createErrorResponse('Invalid path.');
     }
 
@@ -5122,7 +5123,7 @@ class GodotServer {
       return createErrorResponse('projectPath is required.');
     }
 
-    if (!validatePath(args.projectPath)) {
+    if (!validateProjectPath(args.projectPath)) {
       return createErrorResponse('Invalid path.');
     }
 
@@ -5266,7 +5267,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.filePath)
       return createErrorResponse('projectPath and filePath are required.');
-    if (!validatePath(args.projectPath) || !validatePath(args.filePath))
+    if (!validateProjectPath(args.projectPath) || !validatePath(args.filePath))
       return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
@@ -5286,7 +5287,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.filePath || args.content === undefined)
       return createErrorResponse('projectPath, filePath, and content are required.');
-    if (!validatePath(args.projectPath) || !validatePath(args.filePath))
+    if (!validateProjectPath(args.projectPath) || !validatePath(args.filePath))
       return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
@@ -5308,7 +5309,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.filePath)
       return createErrorResponse('projectPath and filePath are required.');
-    if (!validatePath(args.projectPath) || !validatePath(args.filePath))
+    if (!validateProjectPath(args.projectPath) || !validatePath(args.filePath))
       return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
@@ -5328,7 +5329,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.directoryPath)
       return createErrorResponse('projectPath and directoryPath are required.');
-    if (!validatePath(args.projectPath) || !validatePath(args.directoryPath))
+    if (!validateProjectPath(args.projectPath) || !validatePath(args.directoryPath))
       return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
@@ -5411,7 +5412,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.projectName)
       return createErrorResponse('projectPath and projectName are required.');
-    if (!validatePath(args.projectPath))
+    if (!validateProjectPath(args.projectPath))
       return createErrorResponse('Invalid path.');
     try {
       const fsProjectPath = toWslProjectPath(args.projectPath);
@@ -5433,7 +5434,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.action)
       return createErrorResponse('projectPath and action are required.');
-    if (!validatePath(args.projectPath))
+    if (!validateProjectPath(args.projectPath))
       return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
@@ -5474,7 +5475,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.action)
       return createErrorResponse('projectPath and action are required.');
-    if (!validatePath(args.projectPath))
+    if (!validateProjectPath(args.projectPath))
       return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
@@ -5536,7 +5537,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.action)
       return createErrorResponse('projectPath and action are required.');
-    if (!validatePath(args.projectPath))
+    if (!validateProjectPath(args.projectPath))
       return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
@@ -5775,7 +5776,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.presetName || !args.outputPath)
       return createErrorResponse('projectPath, presetName, and outputPath are required.');
-    if (!validatePath(args.projectPath))
+    if (!validateProjectPath(args.projectPath))
       return createErrorResponse('Invalid project path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
@@ -6392,7 +6393,7 @@ class GodotServer {
   private async handleRenameFile(args: any) {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.filePath || !args.newPath) return createErrorResponse('projectPath, filePath, and newPath are required.');
-    if (!validatePath(args.projectPath) || !validatePath(args.filePath) || !validatePath(args.newPath)) return createErrorResponse('Invalid path.');
+    if (!validateProjectPath(args.projectPath) || !validatePath(args.filePath) || !validatePath(args.newPath)) return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     const srcFull = projectFilePath(args.projectPath, args.filePath);
@@ -6420,7 +6421,7 @@ class GodotServer {
   private async handleCreateScript(args: any) {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.scriptPath) return createErrorResponse('projectPath and scriptPath are required.');
-    if (!validatePath(args.projectPath) || !validatePath(args.scriptPath)) return createErrorResponse('Invalid path.');
+    if (!validateProjectPath(args.projectPath) || !validatePath(args.scriptPath)) return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     try {
@@ -6468,7 +6469,7 @@ class GodotServer {
   private async handleManageLayers(args: any) {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.action) return createErrorResponse('projectPath and action are required.');
-    if (!validatePath(args.projectPath)) return createErrorResponse('Invalid path.');
+    if (!validateProjectPath(args.projectPath)) return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     try {
@@ -6504,7 +6505,7 @@ class GodotServer {
   private async handleManagePlugins(args: any) {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.action) return createErrorResponse('projectPath and action are required.');
-    if (!validatePath(args.projectPath)) return createErrorResponse('Invalid path.');
+    if (!validateProjectPath(args.projectPath)) return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     try {
@@ -6548,7 +6549,7 @@ class GodotServer {
   private async handleManageShader(args: any) {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.shaderPath || !args.action) return createErrorResponse('projectPath, shaderPath, and action are required.');
-    if (!validatePath(args.projectPath) || !validatePath(args.shaderPath)) return createErrorResponse('Invalid path.');
+    if (!validateProjectPath(args.projectPath) || !validatePath(args.shaderPath)) return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     const fullPath = projectFilePath(args.projectPath, args.shaderPath);
@@ -6586,7 +6587,7 @@ class GodotServer {
   private async handleSetMainScene(args: any) {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.scenePath) return createErrorResponse('projectPath and scenePath are required.');
-    if (!validatePath(args.projectPath)) return createErrorResponse('Invalid path.');
+    if (!validateProjectPath(args.projectPath)) return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     try {
@@ -6627,7 +6628,7 @@ class GodotServer {
   private async handleManageTranslations(args: any) {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.action) return createErrorResponse('projectPath and action are required.');
-    if (!validatePath(args.projectPath)) return createErrorResponse('Invalid path.');
+    if (!validateProjectPath(args.projectPath)) return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     try {
@@ -6845,7 +6846,7 @@ class GodotServer {
   private async handleManageCiPipeline(args: any) {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.action) return createErrorResponse('projectPath and action are required.');
-    if (!validatePath(args.projectPath)) return createErrorResponse('Invalid path.');
+    if (!validateProjectPath(args.projectPath)) return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     const workflowDir = projectFilePath(args.projectPath, '.github', 'workflows');
@@ -6873,7 +6874,7 @@ class GodotServer {
   private async handleManageDockerExport(args: any) {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.action) return createErrorResponse('projectPath and action are required.');
-    if (!validatePath(args.projectPath)) return createErrorResponse('Invalid path.');
+    if (!validateProjectPath(args.projectPath)) return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     const dockerfilePath = projectFilePath(args.projectPath, 'Dockerfile');
@@ -6909,7 +6910,7 @@ class GodotServer {
       );
     }
 
-    if (!validatePath(args.projectPath)) {
+    if (!validateProjectPath(args.projectPath)) {
       return createErrorResponse(
         'Invalid project path'
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,12 @@ import {
   validatePath,
   createErrorResponse,
   isGodot44OrLater,
+  toWslProjectPath,
+  toNativeProjectPath,
+  isWindowsGodotExe,
+  projectGodotFile,
+  toWindowsAccessiblePath,
+  parseGodotIni,
   type OperationParams,
 } from './utils.js';
 import { ToolFilter, type ToolDef } from './tool-filter.js';
@@ -227,6 +233,16 @@ class GodotServer {
   }
 
   /**
+   * Return the project path form that the configured Godot executable
+   * expects. When Godot is a Windows .exe invoked via WSL interop, convert
+   * /mnt/c/... to C:/... so Godot can open the project. Otherwise pass
+   * through.
+   */
+  private godotSpawnPath(projectPath: string): string {
+    return isWindowsGodotExe(this.godotPath) ? toNativeProjectPath(projectPath) : projectPath;
+  }
+
+  /**
    * Detect the Godot executable path based on the operating system
    */
   private async detectGodotPath() {
@@ -236,17 +252,15 @@ class GodotServer {
       return;
     }
 
-    // Check environment variable next
+    // Check environment variable next. Trust the user's explicit choice and
+    // skip pre-validation — execFile --version can fail silently through WSL
+    // interop, bad pipes, or non-zero exit, and falling through to autodetect
+    // hides the real error. Let the first real invocation surface it.
     if (process.env.GODOT_PATH) {
       const normalizedPath = normalize(process.env.GODOT_PATH);
-      this.logDebug(`Checking GODOT_PATH environment variable: ${normalizedPath}`);
-      if (await this.isValidGodotPath(normalizedPath)) {
-        this.godotPath = normalizedPath;
-        this.logDebug(`Using Godot path from environment: ${this.godotPath}`);
-        return;
-      } else {
-        this.logDebug(`GODOT_PATH environment variable is invalid`);
-      }
+      this.godotPath = normalizedPath;
+      this.logDebug(`Using GODOT_PATH from env (pre-validation skipped): ${normalizedPath}`);
+      return;
     }
 
     // Auto-detect based on platform
@@ -295,7 +309,10 @@ class GodotServer {
 
     // If we get here, we couldn't find Godot
     this.logDebug(`Warning: Could not find Godot in common locations for ${osPlatform}`);
-    console.error(`[SERVER] Could not find Godot in common locations for ${osPlatform}`);
+    const envNote = process.env.GODOT_PATH
+      ? ` (GODOT_PATH=${process.env.GODOT_PATH} did not resolve to a usable binary)`
+      : '';
+    console.error(`[SERVER] Could not find Godot in common locations for ${osPlatform}${envNote}`);
     console.error(`[SERVER] Set GODOT_PATH=/path/to/godot environment variable or pass { godotPath: '/path/to/godot' } in the config to specify the correct path.`);
 
     if (this.strictPathValidation) {
@@ -344,7 +361,7 @@ class GodotServer {
    * Inject the interaction server script into the Godot project
    */
   private injectInteractionServer(projectPath: string): void {
-    const projectFile = join(projectPath, 'project.godot');
+    const projectFile = projectGodotFile(projectPath);
     const destScript = join(projectPath, 'mcp_interaction_server.gd');
 
     // Copy the interaction script into the project
@@ -378,7 +395,7 @@ class GodotServer {
    * Remove the interaction server script and autoload from the project
    */
   private removeInteractionServer(projectPath: string): void {
-    const projectFile = join(projectPath, 'project.godot');
+    const projectFile = projectGodotFile(projectPath);
     const destScript = join(projectPath, 'mcp_interaction_server.gd');
 
     // Remove autoload line from project.godot
@@ -573,7 +590,7 @@ class GodotServer {
     if (!projectPath) return createErrorResponse('projectPath is required.');
     if (!validatePath(projectPath)) return createErrorResponse('Invalid path.');
 
-    const projectFile = join(projectPath, 'project.godot');
+    const projectFile = projectGodotFile(projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${projectPath}`);
 
     try {
@@ -622,9 +639,9 @@ class GodotServer {
       const args = [
         '--headless',
         '--path',
-        projectPath,  // Safe: passed as argument, not interpolated into shell command
+        this.godotSpawnPath(projectPath),  // Translate /mnt/c/... → C:/... for Windows Godot
         '--script',
-        this.operationsScriptPath,
+        toWindowsAccessiblePath(this.operationsScriptPath, this.godotPath),
         operation,
         paramsJson,  // Safe: passed as argument, not interpreted by shell
       ];
@@ -716,7 +733,7 @@ class GodotServer {
 
     try {
       // Check if the directory itself is a Godot project
-      const projectFile = join(directory, 'project.godot');
+      const projectFile = projectGodotFile(directory);
       if (existsSync(projectFile)) {
         projects.push({
           path: directory,
@@ -730,7 +747,7 @@ class GodotServer {
         for (const entry of entries) {
           if (entry.isDirectory()) {
             const subdir = join(directory, entry.name);
-            const projectFile = join(subdir, 'project.godot');
+            const projectFile = projectGodotFile(subdir);
             if (existsSync(projectFile)) {
               projects.push({
                 path: subdir,
@@ -750,7 +767,7 @@ class GodotServer {
               continue;
             }
             // Check if this directory is a Godot project
-            const projectFile = join(subdir, 'project.godot');
+            const projectFile = projectGodotFile(subdir);
             if (existsSync(projectFile)) {
               projects.push({
                 path: subdir,
@@ -3737,7 +3754,7 @@ class GodotServer {
       }
 
       // Check if the project directory exists and contains a project.godot file
-      const projectFile = join(args.projectPath, 'project.godot');
+      const projectFile = projectGodotFile(args.projectPath);
       if (!existsSync(projectFile)) {
         return createErrorResponse(
           `Not a valid Godot project: ${args.projectPath}`
@@ -3745,7 +3762,7 @@ class GodotServer {
       }
 
       this.logDebug(`Launching Godot editor for project: ${args.projectPath}`);
-      const process = spawn(this.godotPath, ['-e', '--path', args.projectPath], {
+      const process = spawn(this.godotPath, ['-e', '--path', this.godotSpawnPath(args.projectPath)], {
         stdio: 'pipe',
       });
 
@@ -3791,7 +3808,7 @@ class GodotServer {
 
     try {
       // Check if the project directory exists and contains a project.godot file
-      const projectFile = join(args.projectPath, 'project.godot');
+      const projectFile = projectGodotFile(args.projectPath);
       if (!existsSync(projectFile)) {
         return createErrorResponse(
           `Not a valid Godot project: ${args.projectPath}`
@@ -3811,7 +3828,7 @@ class GodotServer {
       // Inject interaction server before launching
       this.injectInteractionServer(args.projectPath);
 
-      const cmdArgs = ['-d', '--path', args.projectPath];
+      const cmdArgs = ['-d', '--path', this.godotSpawnPath(args.projectPath)];
       if (args.scene && validatePath(args.scene)) {
         this.logDebug(`Adding scene parameter: ${args.scene}`);
         cmdArgs.push(args.scene);
@@ -4121,7 +4138,7 @@ class GodotServer {
       }
   
       // Check if the project directory exists and contains a project.godot file
-      const projectFile = join(args.projectPath, 'project.godot');
+      const projectFile = projectGodotFile(args.projectPath);
       if (!existsSync(projectFile)) {
         return createErrorResponse(
           `Not a valid Godot project: ${args.projectPath}`
@@ -4196,7 +4213,7 @@ class GodotServer {
 
     try {
       // Check if the project directory exists and contains a project.godot file
-      const projectFile = join(args.projectPath, 'project.godot');
+      const projectFile = projectGodotFile(args.projectPath);
       if (!existsSync(projectFile)) {
         return createErrorResponse(
           `Not a valid Godot project: ${args.projectPath}`
@@ -4254,7 +4271,7 @@ class GodotServer {
 
     try {
       // Check if the project directory exists and contains a project.godot file
-      const projectFile = join(args.projectPath, 'project.godot');
+      const projectFile = projectGodotFile(args.projectPath);
       if (!existsSync(projectFile)) {
         return createErrorResponse(
           `Not a valid Godot project: ${args.projectPath}`
@@ -4335,7 +4352,7 @@ class GodotServer {
 
     try {
       // Check if the project directory exists and contains a project.godot file
-      const projectFile = join(args.projectPath, 'project.godot');
+      const projectFile = projectGodotFile(args.projectPath);
       if (!existsSync(projectFile)) {
         return createErrorResponse(
           `Not a valid Godot project: ${args.projectPath}`
@@ -4414,7 +4431,7 @@ class GodotServer {
 
     try {
       // Check if the project directory exists and contains a project.godot file
-      const projectFile = join(args.projectPath, 'project.godot');
+      const projectFile = projectGodotFile(args.projectPath);
       if (!existsSync(projectFile)) {
         return createErrorResponse(
           `Not a valid Godot project: ${args.projectPath}`
@@ -4492,7 +4509,7 @@ class GodotServer {
 
     try {
       // Check if the project directory exists and contains a project.godot file
-      const projectFile = join(args.projectPath, 'project.godot');
+      const projectFile = projectGodotFile(args.projectPath);
       if (!existsSync(projectFile)) {
         return createErrorResponse(
           `Not a valid Godot project: ${args.projectPath}`
@@ -4573,7 +4590,7 @@ class GodotServer {
       }
 
       // Check if the project directory exists and contains a project.godot file
-      const projectFile = join(args.projectPath, 'project.godot');
+      const projectFile = projectGodotFile(args.projectPath);
       if (!existsSync(projectFile)) {
         return createErrorResponse(
           `Not a valid Godot project: ${args.projectPath}`
@@ -4612,11 +4629,20 @@ class GodotServer {
         );
       }
 
+      // Godot prints its engine banner before any script output, so we can't
+      // just trim stdout. UIDs always start with uid://.
+      const uidMatch = stdout.match(/uid:\/\/[a-z0-9]+/i);
+      if (!uidMatch) {
+        return createErrorResponse(
+          `No UID found for ${args.filePath}. Godot stdout: ${stdout.trim() || '(empty)'}`
+        );
+      }
+
       return {
         content: [
           {
             type: 'text',
-            text: `UID for ${args.filePath}: ${stdout.trim()}`,
+            text: `UID for ${args.filePath}: ${uidMatch[0]}`,
           },
         ],
       };
@@ -4770,7 +4796,7 @@ class GodotServer {
       return createErrorResponse('Invalid path.');
     }
 
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) {
       return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     }
@@ -4850,39 +4876,14 @@ class GodotServer {
       return createErrorResponse('Invalid path.');
     }
 
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) {
       return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     }
 
     try {
       const content = readFileSync(projectFile, 'utf8');
-      const sections: Record<string, Record<string, string>> = {};
-      let currentSection = '';
-
-      for (const line of content.split('\n')) {
-        const trimmed = line.trim();
-        if (trimmed === '' || trimmed.startsWith(';')) continue;
-
-        // Section header
-        const sectionMatch = trimmed.match(/^\[(.+)\]$/);
-        if (sectionMatch) {
-          currentSection = sectionMatch[1];
-          if (!sections[currentSection]) {
-            sections[currentSection] = {};
-          }
-          continue;
-        }
-
-        // Key=value pair
-        const kvMatch = trimmed.match(/^([^=]+)=(.*)$/);
-        if (kvMatch && currentSection) {
-          const key = kvMatch[1].trim();
-          const value = kvMatch[2].trim();
-          sections[currentSection][key] = value;
-        }
-      }
-
+      const sections = parseGodotIni(content);
       return {
         content: [{ type: 'text', text: JSON.stringify(sections, null, 2) }],
       };
@@ -4904,7 +4905,7 @@ class GodotServer {
       return createErrorResponse('Invalid path.');
     }
 
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) {
       return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     }
@@ -5104,7 +5105,7 @@ class GodotServer {
       return createErrorResponse('projectPath and filePath are required.');
     if (!validatePath(args.projectPath) || !validatePath(args.filePath))
       return createErrorResponse('Invalid path.');
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
       return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     const fullPath = join(args.projectPath, args.filePath);
@@ -5124,7 +5125,7 @@ class GodotServer {
       return createErrorResponse('projectPath, filePath, and content are required.');
     if (!validatePath(args.projectPath) || !validatePath(args.filePath))
       return createErrorResponse('Invalid path.');
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
       return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     try {
@@ -5146,7 +5147,7 @@ class GodotServer {
       return createErrorResponse('projectPath and filePath are required.');
     if (!validatePath(args.projectPath) || !validatePath(args.filePath))
       return createErrorResponse('Invalid path.');
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
       return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     const fullPath = join(args.projectPath, args.filePath);
@@ -5166,7 +5167,7 @@ class GodotServer {
       return createErrorResponse('projectPath and directoryPath are required.');
     if (!validatePath(args.projectPath) || !validatePath(args.directoryPath))
       return createErrorResponse('Invalid path.');
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
       return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     try {
@@ -5253,7 +5254,7 @@ class GodotServer {
       if (!existsSync(args.projectPath)) {
         mkdirSync(args.projectPath, { recursive: true });
       }
-      const projectFile = join(args.projectPath, 'project.godot');
+      const projectFile = projectGodotFile(args.projectPath);
       if (existsSync(projectFile))
         return createErrorResponse('A project.godot already exists at this path.');
       const content = `; Engine configuration file.\n; Generated by Godot MCP.\n\nconfig_version=5\n\n[application]\n\nconfig/name="${args.projectName}"\nconfig/features=PackedStringArray("4.3")\n`;
@@ -5270,7 +5271,7 @@ class GodotServer {
       return createErrorResponse('projectPath and action are required.');
     if (!validatePath(args.projectPath))
       return createErrorResponse('Invalid path.');
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
       return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     try {
@@ -5316,20 +5317,14 @@ class GodotServer {
       return createErrorResponse('projectPath and action are required.');
     if (!validatePath(args.projectPath))
       return createErrorResponse('Invalid path.');
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
       return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     try {
       let content = readFileSync(projectFile, 'utf8');
       if (args.action === 'list') {
-        const actions: Record<string, string> = {};
-        const inputMatch = content.match(/\[input\]([\s\S]*?)(?=\n\[|$)/);
-        if (inputMatch) {
-          for (const line of inputMatch[1].split('\n')) {
-            const kv = line.trim().match(/^([^=]+)=(.*)$/);
-            if (kv) actions[kv[1].trim()] = kv[2].trim();
-          }
-        }
+        const sections = parseGodotIni(content);
+        const actions = sections['input'] || {};
         return { content: [{ type: 'text', text: JSON.stringify(actions, null, 2) }] };
       } else if (args.action === 'add') {
         if (!args.actionName)
@@ -5384,7 +5379,7 @@ class GodotServer {
       return createErrorResponse('projectPath and action are required.');
     if (!validatePath(args.projectPath))
       return createErrorResponse('Invalid path.');
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
       return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     const presetsFile = join(args.projectPath, 'export_presets.cfg');
@@ -5623,7 +5618,7 @@ class GodotServer {
       return createErrorResponse('projectPath, presetName, and outputPath are required.');
     if (!validatePath(args.projectPath))
       return createErrorResponse('Invalid project path.');
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
       return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     if (!this.godotPath) {
@@ -5632,7 +5627,7 @@ class GodotServer {
     }
     try {
       const exportFlag = args.debug ? '--export-debug' : '--export-release';
-      const exportArgs = ['--headless', '--path', args.projectPath, exportFlag, args.presetName, args.outputPath];
+      const exportArgs = ['--headless', '--path', this.godotSpawnPath(args.projectPath), exportFlag, args.presetName, args.outputPath];
       const { stdout, stderr } = await execFileAsync(this.godotPath!, exportArgs, { timeout: 120000 });
       if (stderr && stderr.includes('ERROR'))
         return createErrorResponse(`Export failed: ${stderr}`);
@@ -6237,7 +6232,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.filePath || !args.newPath) return createErrorResponse('projectPath, filePath, and newPath are required.');
     if (!validatePath(args.projectPath) || !validatePath(args.filePath) || !validatePath(args.newPath)) return createErrorResponse('Invalid path.');
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     const srcFull = join(args.projectPath, args.filePath);
     const dstFull = join(args.projectPath, args.newPath);
@@ -6265,7 +6260,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.scriptPath) return createErrorResponse('projectPath and scriptPath are required.');
     if (!validatePath(args.projectPath) || !validatePath(args.scriptPath)) return createErrorResponse('Invalid path.');
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     try {
       const fullPath = join(args.projectPath, args.scriptPath);
@@ -6313,7 +6308,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.action) return createErrorResponse('projectPath and action are required.');
     if (!validatePath(args.projectPath)) return createErrorResponse('Invalid path.');
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     try {
       let content = readFileSync(projectFile, 'utf8');
@@ -6349,7 +6344,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.action) return createErrorResponse('projectPath and action are required.');
     if (!validatePath(args.projectPath)) return createErrorResponse('Invalid path.');
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     try {
       let content = readFileSync(projectFile, 'utf8');
@@ -6393,7 +6388,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.shaderPath || !args.action) return createErrorResponse('projectPath, shaderPath, and action are required.');
     if (!validatePath(args.projectPath) || !validatePath(args.shaderPath)) return createErrorResponse('Invalid path.');
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     const fullPath = join(args.projectPath, args.shaderPath);
     try {
@@ -6431,7 +6426,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.scenePath) return createErrorResponse('projectPath and scenePath are required.');
     if (!validatePath(args.projectPath)) return createErrorResponse('Invalid path.');
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     try {
       let content = readFileSync(projectFile, 'utf8');
@@ -6472,7 +6467,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.action) return createErrorResponse('projectPath and action are required.');
     if (!validatePath(args.projectPath)) return createErrorResponse('Invalid path.');
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     try {
       let content = readFileSync(projectFile, 'utf8');
@@ -6690,7 +6685,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.action) return createErrorResponse('projectPath and action are required.');
     if (!validatePath(args.projectPath)) return createErrorResponse('Invalid path.');
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     const workflowDir = join(args.projectPath, '.github', 'workflows');
     const workflowPath = join(workflowDir, 'godot-export.yml');
@@ -6718,7 +6713,7 @@ class GodotServer {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.action) return createErrorResponse('projectPath and action are required.');
     if (!validatePath(args.projectPath)) return createErrorResponse('Invalid path.');
-    const projectFile = join(args.projectPath, 'project.godot');
+    const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     const dockerfilePath = join(args.projectPath, 'Dockerfile');
     try {
@@ -6771,7 +6766,7 @@ class GodotServer {
       }
 
       // Check if the project directory exists and contains a project.godot file
-      const projectFile = join(args.projectPath, 'project.godot');
+      const projectFile = projectGodotFile(args.projectPath);
       if (!existsSync(projectFile)) {
         return createErrorResponse(
           `Not a valid Godot project: ${args.projectPath}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ class GodotServer {
   private interactionScriptPath: string;
   private validatedPaths: Map<string, boolean> = new Map();
   private strictPathValidation: boolean = false;
-  private toolFilter: ToolFilter;
+  private readonly toolFilter: ToolFilter;
   private gameConnection: GameConnection = {
     socket: null,
     connected: false,
@@ -4583,7 +4583,7 @@ class GodotServer {
         };
       }
     }
-    const uidMatch = stdout.match(/uid:\/\/[a-z0-9]+/i);
+    const uidMatch = /uid:\/\/[a-z\d]+/i.exec(stdout);
     return uidMatch ? uidMatch[0] : null;
   }
 
@@ -6892,36 +6892,39 @@ class GodotServer {
 function extractTrailingJson(blob: string): any {
   const start = blob.indexOf('{');
   if (start === -1) return null;
+  const end = findMatchingBrace(blob, start);
+  if (end === -1) return null;
+  try {
+    return JSON.parse(blob.slice(start, end + 1));
+  } catch {
+    return null;
+  }
+}
+
+// Return the index of the `}` that closes the `{` at `start`, or -1 if the
+// blob ends mid-object. Skips characters that live inside string literals.
+function findMatchingBrace(blob: string, start: number): number {
   let depth = 0;
   let inString = false;
   for (let i = start; i < blob.length; i++) {
     const ch = blob[i];
     if (inString) {
       if (ch === '\\') {
-        // Skip the escaped character.
-        i++;
-        continue;
+        i++; // skip the escaped character
+      } else if (ch === '"') {
+        inString = false;
       }
-      if (ch === '"') inString = false;
       continue;
     }
     if (ch === '"') {
       inString = true;
-      continue;
-    }
-    if (ch === '{') depth++;
-    else if (ch === '}') {
-      depth--;
-      if (depth === 0) {
-        try {
-          return JSON.parse(blob.slice(start, i + 1));
-        } catch {
-          return null;
-        }
-      }
+    } else if (ch === '{') {
+      depth++;
+    } else if (ch === '}' && --depth === 0) {
+      return i;
     }
   }
-  return null;
+  return -1;
 }
 
 // Create and run the server

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import {
   isGodot44OrLater,
   type OperationParams,
 } from './utils.js';
+import { ToolFilter, type ToolDef } from './tool-filter.js';
 
 // Check if debug mode is enabled
 const DEBUG_MODE: boolean = process.env.DEBUG === 'true';
@@ -85,6 +86,7 @@ class GodotServer {
   private interactionScriptPath: string;
   private validatedPaths: Map<string, boolean> = new Map();
   private strictPathValidation: boolean = false;
+  private toolFilter: ToolFilter;
   private gameConnection: GameConnection = {
     socket: null,
     connected: false,
@@ -131,6 +133,10 @@ class GodotServer {
     this.operationsScriptPath = join(__dirname, 'scripts', 'godot_operations.gd');
     this.interactionScriptPath = join(__dirname, 'scripts', 'mcp_interaction_server.gd');
     if (debugMode) console.error(`[DEBUG] Operations script path: ${this.operationsScriptPath}`);
+
+    // Load the tool filter from environment / config file. Bad config throws
+    // and the top-level entry point converts it into a non-zero exit.
+    this.toolFilter = ToolFilter.load();
 
     // Initialize the MCP server
     this.server = new Server(
@@ -769,11 +775,11 @@ class GodotServer {
    */
   private setupToolHandlers() {
     // Define available tools
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
-      tools: [
+    const allTools: ToolDef[] = [
         {
           name: 'launch_editor',
           description: 'Launch Godot editor for a specific project',
+          tags: ['editor'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -788,6 +794,7 @@ class GodotServer {
         {
           name: 'run_project',
           description: 'Run the Godot project and capture output',
+          tags: ['editor', 'runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -806,6 +813,7 @@ class GodotServer {
         {
           name: 'get_debug_output',
           description: 'Get the current debug output and errors',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {},
@@ -815,6 +823,7 @@ class GodotServer {
         {
           name: 'stop_project',
           description: 'Stop the currently running Godot project',
+          tags: ['editor', 'runtime'],
           inputSchema: {
             type: 'object',
             properties: {},
@@ -824,6 +833,7 @@ class GodotServer {
         {
           name: 'get_godot_version',
           description: 'Get the installed Godot version',
+          tags: ['editor'],
           inputSchema: {
             type: 'object',
             properties: {},
@@ -833,6 +843,7 @@ class GodotServer {
         {
           name: 'list_projects',
           description: 'List Godot projects in a directory',
+          tags: ['project'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -851,6 +862,7 @@ class GodotServer {
         {
           name: 'get_project_info',
           description: 'Retrieve metadata about a Godot project',
+          tags: ['project'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -865,6 +877,7 @@ class GodotServer {
         {
           name: 'create_scene',
           description: 'Create a new Godot scene file',
+          tags: ['scene', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -887,6 +900,7 @@ class GodotServer {
         {
           name: 'add_node',
           description: 'Add a node to an existing scene',
+          tags: ['scene', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -921,6 +935,7 @@ class GodotServer {
         {
           name: 'load_sprite',
           description: 'Load a sprite into a Sprite2D node',
+          tags: ['scene', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -947,6 +962,7 @@ class GodotServer {
         {
           name: 'export_mesh_library',
           description: 'Export a scene as a MeshLibrary resource',
+          tags: ['3d', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -976,6 +992,7 @@ class GodotServer {
         {
           name: 'save_scene',
           description: 'Save changes to a scene file',
+          tags: ['scene', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -998,6 +1015,7 @@ class GodotServer {
         {
           name: 'get_uid',
           description: 'Get the UID for a specific file in a Godot project (for Godot 4.4+)',
+          tags: ['headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1016,6 +1034,7 @@ class GodotServer {
         {
           name: 'update_project_uids',
           description: 'Update UID references by resaving resources (4.4+)',
+          tags: ['project', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1030,6 +1049,7 @@ class GodotServer {
         {
           name: 'game_screenshot',
           description: 'Screenshot the running game (returns base64 PNG)',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {},
@@ -1039,6 +1059,7 @@ class GodotServer {
         {
           name: 'game_click',
           description: 'Click at a position in the running Godot game window',
+          tags: ['runtime', 'input'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1061,6 +1082,7 @@ class GodotServer {
         {
           name: 'game_key_press',
           description: 'Send a key press or input action to the running game',
+          tags: ['runtime', 'input'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1083,6 +1105,7 @@ class GodotServer {
         {
           name: 'game_mouse_move',
           description: 'Move the mouse in the running Godot game',
+          tags: ['runtime', 'input'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1109,6 +1132,7 @@ class GodotServer {
         {
           name: 'game_get_ui',
           description: 'Get visible UI elements from the running game',
+          tags: ['runtime', 'ui'],
           inputSchema: {
             type: 'object',
             properties: {},
@@ -1118,6 +1142,7 @@ class GodotServer {
         {
           name: 'game_get_scene_tree',
           description: 'Get scene tree structure of the running game',
+          tags: ['runtime', 'scene'],
           inputSchema: {
             type: 'object',
             properties: {},
@@ -1127,6 +1152,7 @@ class GodotServer {
 {
           name: 'game_eval',
           description: 'Execute GDScript in the running game. Use "return" for values.',
+          tags: ['runtime', 'gdscript-only'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1141,6 +1167,7 @@ class GodotServer {
         {
           name: 'game_get_property',
           description: 'Get a property value from any node in the running game by its path',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1159,6 +1186,7 @@ class GodotServer {
         {
           name: 'game_set_property',
           description: 'Set a property on a node in the running game',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1184,6 +1212,7 @@ class GodotServer {
         {
           name: 'game_call_method',
           description: 'Call a method on any node in the running game with optional arguments',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1206,6 +1235,7 @@ class GodotServer {
         {
           name: 'game_get_node_info',
           description: 'Get node info: class, properties, signals, methods, children',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1220,6 +1250,7 @@ class GodotServer {
         {
           name: 'game_instantiate_scene',
           description: 'Load a PackedScene and add it as a child of a node in the running game',
+          tags: ['runtime', 'scene'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1238,6 +1269,7 @@ class GodotServer {
         {
           name: 'game_remove_node',
           description: 'Remove and free a node from the running game\'s scene tree',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1252,6 +1284,7 @@ class GodotServer {
         {
           name: 'game_change_scene',
           description: 'Switch to a different scene file in the running game',
+          tags: ['runtime', 'scene'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1266,6 +1299,7 @@ class GodotServer {
         {
           name: 'game_pause',
           description: 'Pause or unpause the running game',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1280,6 +1314,7 @@ class GodotServer {
         {
           name: 'game_performance',
           description: 'Get performance metrics (FPS, memory, draw calls)',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {},
@@ -1289,6 +1324,7 @@ class GodotServer {
         {
           name: 'game_wait',
           description: 'Wait N frames in the running game',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1303,6 +1339,7 @@ class GodotServer {
 {
           name: 'read_scene',
           description: 'Read scene file as JSON node tree (headless)',
+          tags: ['scene', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1321,6 +1358,7 @@ class GodotServer {
         {
           name: 'modify_scene_node',
           description: 'Modify node properties in a scene file (headless)',
+          tags: ['scene', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1347,6 +1385,7 @@ class GodotServer {
         {
           name: 'remove_scene_node',
           description: 'Remove a node from a scene file (headless)',
+          tags: ['scene', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1369,6 +1408,7 @@ class GodotServer {
 {
           name: 'read_project_settings',
           description: 'Read project.godot as structured JSON',
+          tags: ['project', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1383,6 +1423,7 @@ class GodotServer {
         {
           name: 'modify_project_settings',
           description: 'Modify a project.godot setting',
+          tags: ['project', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1409,6 +1450,7 @@ class GodotServer {
         {
           name: 'list_project_files',
           description: 'List project files, optionally filtered by extension',
+          tags: ['file-io', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1432,6 +1474,7 @@ class GodotServer {
 {
           name: 'game_connect_signal',
           description: 'Connect a signal from one node to a method on another node in the running game',
+          tags: ['runtime', 'signal'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1446,6 +1489,7 @@ class GodotServer {
         {
           name: 'game_disconnect_signal',
           description: 'Disconnect a signal connection in the running game',
+          tags: ['runtime', 'signal'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1460,6 +1504,7 @@ class GodotServer {
         {
           name: 'game_emit_signal',
           description: 'Emit a signal on a node in the running game, optionally with arguments',
+          tags: ['runtime', 'signal'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1473,6 +1518,7 @@ class GodotServer {
         {
           name: 'game_play_animation',
           description: 'Control an AnimationPlayer node: play, stop, pause, or list animations',
+          tags: ['runtime', 'animation'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1486,6 +1532,7 @@ class GodotServer {
         {
           name: 'game_tween_property',
           description: 'Tween a node property in the running game',
+          tags: ['runtime', 'animation'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1502,6 +1549,7 @@ class GodotServer {
         {
           name: 'game_get_nodes_in_group',
           description: 'Get all nodes belonging to a specific group in the running game',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1513,6 +1561,7 @@ class GodotServer {
         {
           name: 'game_find_nodes_by_class',
           description: 'Find all nodes of a specific class type in the running game',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1525,6 +1574,7 @@ class GodotServer {
         {
           name: 'game_reparent_node',
           description: 'Move a node to a new parent in the running game\'s scene tree',
+          tags: ['runtime', 'scene'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1538,6 +1588,7 @@ class GodotServer {
 {
           name: 'attach_script',
           description: 'Attach a GDScript to a scene node (headless)',
+          tags: ['script', 'gdscript-only', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1552,6 +1603,7 @@ class GodotServer {
         {
           name: 'create_resource',
           description: 'Create a .tres resource file (headless)',
+          tags: ['scene', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1567,6 +1619,7 @@ class GodotServer {
         {
           name: 'read_file',
           description: 'Read a text file from a Godot project',
+          tags: ['file-io'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1579,6 +1632,7 @@ class GodotServer {
         {
           name: 'write_file',
           description: 'Create or overwrite a text file in a Godot project',
+          tags: ['file-io'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1592,6 +1646,7 @@ class GodotServer {
         {
           name: 'delete_file',
           description: 'Delete a file from a Godot project',
+          tags: ['file-io'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1604,6 +1659,7 @@ class GodotServer {
         {
           name: 'create_directory',
           description: 'Create a directory inside a Godot project',
+          tags: ['file-io'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1617,6 +1673,7 @@ class GodotServer {
         {
           name: 'game_get_errors',
           description: 'Get new push_error/push_warning messages since last call',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {},
@@ -1626,6 +1683,7 @@ class GodotServer {
         {
           name: 'game_get_logs',
           description: 'Get new print output from the running game since last call',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {},
@@ -1636,6 +1694,7 @@ class GodotServer {
         {
           name: 'game_key_hold',
           description: 'Hold a key down without auto-releasing',
+          tags: ['runtime', 'input'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1648,6 +1707,7 @@ class GodotServer {
         {
           name: 'game_key_release',
           description: 'Release a previously held key',
+          tags: ['runtime', 'input'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1660,6 +1720,7 @@ class GodotServer {
         {
           name: 'game_scroll',
           description: 'Send mouse scroll wheel event at position',
+          tags: ['runtime', 'input'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1674,6 +1735,7 @@ class GodotServer {
         {
           name: 'game_mouse_drag',
           description: 'Drag mouse between two points over N frames',
+          tags: ['runtime', 'input'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1690,6 +1752,7 @@ class GodotServer {
         {
           name: 'game_gamepad',
           description: 'Send gamepad button or axis input event',
+          tags: ['runtime', 'input'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1705,6 +1768,7 @@ class GodotServer {
         {
           name: 'create_project',
           description: 'Create a new Godot project from scratch',
+          tags: ['project'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1717,6 +1781,7 @@ class GodotServer {
         {
           name: 'manage_autoloads',
           description: 'Add, remove, or list autoloads in a Godot project',
+          tags: ['project', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1731,6 +1796,7 @@ class GodotServer {
         {
           name: 'manage_input_map',
           description: 'Add, remove, or list input actions and bindings',
+          tags: ['project', 'input', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1746,6 +1812,7 @@ class GodotServer {
         {
           name: 'manage_export_presets',
           description: 'Create or modify export preset configuration',
+          tags: ['project', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1761,7 +1828,8 @@ class GodotServer {
         // Advanced runtime tools
         {
           name: 'game_get_camera',
-          description: 'Get active camera position, rotation, and size',
+          description: 'Get active camera position, rotation, and size (2D or 3D)',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {},
@@ -1770,7 +1838,8 @@ class GodotServer {
         },
         {
           name: 'game_set_camera',
-          description: 'Move or rotate the active camera',
+          description: 'Move or rotate the active camera (2D or 3D)',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1785,6 +1854,7 @@ class GodotServer {
         {
           name: 'game_raycast',
           description: 'Cast a ray and return collision results',
+          tags: ['runtime', 'physics'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1798,6 +1868,7 @@ class GodotServer {
         {
           name: 'game_get_audio',
           description: 'Get audio bus layout and playing streams',
+          tags: ['runtime', 'audio'],
           inputSchema: {
             type: 'object',
             properties: {},
@@ -1807,6 +1878,7 @@ class GodotServer {
         {
           name: 'game_spawn_node',
           description: 'Create a new node of any type at runtime',
+          tags: ['runtime', 'scene'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1822,6 +1894,7 @@ class GodotServer {
         {
           name: 'game_set_shader_param',
           description: 'Set a shader parameter on a node\'s material',
+          tags: ['runtime', 'shader'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1836,6 +1909,7 @@ class GodotServer {
         {
           name: 'game_audio_play',
           description: 'Play, stop, or pause an AudioStreamPlayer node',
+          tags: ['runtime', 'audio'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1853,6 +1927,7 @@ class GodotServer {
         {
           name: 'game_audio_bus',
           description: 'Set volume, mute, or solo on an audio bus',
+          tags: ['runtime', 'audio'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1867,6 +1942,7 @@ class GodotServer {
         {
           name: 'game_navigate_path',
           description: 'Query a navigation path between two points',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1880,6 +1956,7 @@ class GodotServer {
         {
           name: 'game_tilemap',
           description: 'Get or set cells in a TileMapLayer node',
+          tags: ['runtime', '2d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1896,6 +1973,7 @@ class GodotServer {
         {
           name: 'game_add_collision',
           description: 'Add a collision shape to a physics body node',
+          tags: ['runtime', 'physics'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1912,6 +1990,7 @@ class GodotServer {
         {
           name: 'game_environment',
           description: 'Get or set environment and post-processing settings',
+          tags: ['runtime', 'rendering'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1942,6 +2021,7 @@ class GodotServer {
         {
           name: 'game_manage_group',
           description: 'Add or remove a node from a group, or list groups',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1955,6 +2035,7 @@ class GodotServer {
         {
           name: 'game_create_timer',
           description: 'Create a Timer node with configuration',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1970,6 +2051,7 @@ class GodotServer {
         {
           name: 'game_set_particles',
           description: 'Configure GPUParticles2D/3D node properties',
+          tags: ['runtime', 'animation'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -1989,6 +2071,7 @@ class GodotServer {
         {
           name: 'game_create_animation',
           description: 'Create an animation with tracks and keyframes',
+          tags: ['runtime', 'animation'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2005,6 +2088,7 @@ class GodotServer {
         {
           name: 'export_project',
           description: 'Export a Godot project using a preset',
+          tags: ['project', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2019,6 +2103,7 @@ class GodotServer {
         {
           name: 'game_serialize_state',
           description: 'Save or load node tree state as JSON',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2033,6 +2118,7 @@ class GodotServer {
         {
           name: 'game_physics_body',
           description: 'Configure physics body properties (mass, velocity, etc.)',
+          tags: ['runtime', 'physics'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2054,6 +2140,7 @@ class GodotServer {
         {
           name: 'game_create_joint',
           description: 'Create a physics joint between two bodies',
+          tags: ['runtime', 'physics'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2072,6 +2159,7 @@ class GodotServer {
         {
           name: 'game_bone_pose',
           description: 'Get or set bone poses on a Skeleton3D node',
+          tags: ['runtime', 'animation', '3d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2089,6 +2177,7 @@ class GodotServer {
         {
           name: 'game_ui_theme',
           description: 'Apply theme overrides to a Control node',
+          tags: ['runtime', 'ui'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2101,6 +2190,7 @@ class GodotServer {
         {
           name: 'game_viewport',
           description: 'Create or configure a SubViewport node',
+          tags: ['runtime', 'rendering'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2119,6 +2209,7 @@ class GodotServer {
         {
           name: 'game_debug_draw',
           description: 'Draw debug lines, spheres, or boxes in 3D',
+          tags: ['runtime', 'rendering'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2138,6 +2229,7 @@ class GodotServer {
         {
           name: 'game_http_request',
           description: 'HTTP GET/POST/PUT/DELETE with headers and body',
+          tags: ['runtime', 'networking'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2153,6 +2245,7 @@ class GodotServer {
         {
           name: 'game_websocket',
           description: 'WebSocket client connect/disconnect/send messages',
+          tags: ['runtime', 'networking'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2166,6 +2259,7 @@ class GodotServer {
         {
           name: 'game_multiplayer',
           description: 'ENet multiplayer create server/client/disconnect',
+          tags: ['runtime', 'networking'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2180,6 +2274,7 @@ class GodotServer {
         {
           name: 'game_rpc',
           description: 'Call or configure RPC methods on nodes',
+          tags: ['runtime', 'networking'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2197,6 +2292,7 @@ class GodotServer {
         {
           name: 'game_touch',
           description: 'Simulate touch press/release/drag and gestures',
+          tags: ['runtime', 'input'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2214,6 +2310,7 @@ class GodotServer {
         {
           name: 'game_input_state',
           description: 'Query pressed keys, mouse position, connected pads',
+          tags: ['runtime', 'input'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2228,6 +2325,7 @@ class GodotServer {
         {
           name: 'game_input_action',
           description: 'Manage runtime InputMap actions and strength',
+          tags: ['runtime', 'input'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2242,6 +2340,7 @@ class GodotServer {
         {
           name: 'game_list_signals',
           description: 'List all signals on a node with connections',
+          tags: ['runtime', 'signal'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2253,6 +2352,7 @@ class GodotServer {
         {
           name: 'game_await_signal',
           description: 'Await a signal with timeout and return args',
+          tags: ['runtime', 'signal'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2266,6 +2366,7 @@ class GodotServer {
         {
           name: 'game_script',
           description: 'Attach, detach, or get source of node scripts',
+          tags: ['runtime', 'script', 'gdscript-only'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2280,6 +2381,7 @@ class GodotServer {
         {
           name: 'game_window',
           description: 'Get/set window size, fullscreen, title, position',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2298,6 +2400,7 @@ class GodotServer {
         {
           name: 'game_os_info',
           description: 'Get platform, locale, screen, adapter, memory info',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {},
@@ -2307,6 +2410,7 @@ class GodotServer {
         {
           name: 'game_time_scale',
           description: 'Get/set Engine.time_scale and timing info',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2319,6 +2423,7 @@ class GodotServer {
         {
           name: 'game_process_mode',
           description: 'Set node process mode (pausable/always/disabled)',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2331,6 +2436,7 @@ class GodotServer {
         {
           name: 'game_world_settings',
           description: 'Get/set gravity, physics FPS, and world settings',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2346,6 +2452,7 @@ class GodotServer {
         {
           name: 'game_csg',
           description: 'Create/configure CSG nodes with boolean operations',
+          tags: ['runtime', '3d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2366,6 +2473,7 @@ class GodotServer {
         {
           name: 'game_multimesh',
           description: 'Create/configure MultiMeshInstance3D for instancing',
+          tags: ['runtime', '3d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2384,6 +2492,7 @@ class GodotServer {
         {
           name: 'game_procedural_mesh',
           description: 'Generate meshes via ArrayMesh from vertex data',
+          tags: ['runtime', '3d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2400,6 +2509,7 @@ class GodotServer {
         {
           name: 'game_light_3d',
           description: 'Create/configure 3D lights (directional/omni/spot)',
+          tags: ['runtime', '3d', 'rendering'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2420,6 +2530,7 @@ class GodotServer {
         {
           name: 'game_mesh_instance',
           description: 'Create MeshInstance3D with primitive meshes',
+          tags: ['runtime', '3d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2437,6 +2548,7 @@ class GodotServer {
         {
           name: 'game_gridmap',
           description: 'GridMap set/get/clear cells and query used cells',
+          tags: ['runtime', '3d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2454,6 +2566,7 @@ class GodotServer {
         {
           name: 'game_3d_effects',
           description: 'Create ReflectionProbe, Decal, or FogVolume',
+          tags: ['runtime', '3d', 'rendering'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2469,6 +2582,7 @@ class GodotServer {
         {
           name: 'game_gi',
           description: 'Create/configure VoxelGI or LightmapGI',
+          tags: ['runtime', '3d', 'rendering'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2483,6 +2597,7 @@ class GodotServer {
         {
           name: 'game_path_3d',
           description: 'Create Path3D/Curve3D and manage curve points',
+          tags: ['runtime', '3d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2499,6 +2614,7 @@ class GodotServer {
         {
           name: 'game_sky',
           description: 'Create/configure Sky with procedural/physical sky',
+          tags: ['runtime', '3d', 'rendering'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2515,6 +2631,7 @@ class GodotServer {
         {
           name: 'game_camera_attributes',
           description: 'Configure DOF, exposure, auto-exposure on camera',
+          tags: ['runtime', '3d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2532,6 +2649,7 @@ class GodotServer {
         {
           name: 'game_navigation_3d',
           description: 'Create/configure NavigationRegion3D and bake',
+          tags: ['runtime', '3d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2549,6 +2667,7 @@ class GodotServer {
         {
           name: 'game_physics_3d',
           description: 'Area3D queries and point/shape intersection tests',
+          tags: ['runtime', '3d', 'physics'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2565,6 +2684,7 @@ class GodotServer {
         {
           name: 'game_canvas',
           description: 'Create/configure CanvasLayer and CanvasModulate',
+          tags: ['runtime', '2d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2581,6 +2701,7 @@ class GodotServer {
         {
           name: 'game_canvas_draw',
           description: '2D drawing: line/rect/circle/polygon/text/clear',
+          tags: ['runtime', '2d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2603,6 +2724,7 @@ class GodotServer {
         {
           name: 'game_light_2d',
           description: 'Create/configure 2D lights and light occluders',
+          tags: ['runtime', '2d', 'rendering'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2620,6 +2742,7 @@ class GodotServer {
         {
           name: 'game_parallax',
           description: 'Create/configure ParallaxBackground and layers',
+          tags: ['runtime', '2d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2637,6 +2760,7 @@ class GodotServer {
         {
           name: 'game_shape_2d',
           description: 'Line2D/Polygon2D point manipulation',
+          tags: ['runtime', '2d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2653,6 +2777,7 @@ class GodotServer {
         {
           name: 'game_path_2d',
           description: 'Path2D/Curve2D management and AnimatedSprite2D',
+          tags: ['runtime', '2d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2669,6 +2794,7 @@ class GodotServer {
         {
           name: 'game_physics_2d',
           description: 'Area2D queries and 2D point/shape intersections',
+          tags: ['runtime', '2d', 'physics'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2684,6 +2810,7 @@ class GodotServer {
         {
           name: 'game_animation_tree',
           description: 'AnimationTree state machine travel and params',
+          tags: ['runtime', 'animation'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2699,6 +2826,7 @@ class GodotServer {
         {
           name: 'game_animation_control',
           description: 'AnimationPlayer seek/queue/speed/info control',
+          tags: ['runtime', 'animation'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2714,6 +2842,7 @@ class GodotServer {
         {
           name: 'game_skeleton_ik',
           description: 'SkeletonIK3D start/stop/set target position',
+          tags: ['runtime', 'animation', '3d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2727,6 +2856,7 @@ class GodotServer {
         {
           name: 'game_audio_effect',
           description: 'Add/remove/configure audio bus effects',
+          tags: ['runtime', 'audio'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2742,6 +2872,7 @@ class GodotServer {
         {
           name: 'game_audio_bus_layout',
           description: 'Create/remove/reorder audio buses and routing',
+          tags: ['runtime', 'audio'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2756,6 +2887,7 @@ class GodotServer {
         {
           name: 'game_audio_spatial',
           description: 'Configure AudioStreamPlayer3D spatial properties',
+          tags: ['runtime', 'audio', '3d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2773,6 +2905,7 @@ class GodotServer {
         {
           name: 'rename_file',
           description: 'Rename or move a file within the project',
+          tags: ['file-io'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2786,6 +2919,7 @@ class GodotServer {
         {
           name: 'manage_resource',
           description: 'Read or modify .tres/.res resource files',
+          tags: ['headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2800,6 +2934,7 @@ class GodotServer {
         {
           name: 'create_script',
           description: 'Create a GDScript file from a template',
+          tags: ['script', 'gdscript-only', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2816,6 +2951,7 @@ class GodotServer {
         {
           name: 'manage_scene_signals',
           description: 'List/add/remove signal connections in .tscn files',
+          tags: ['scene', 'signal', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2833,6 +2969,7 @@ class GodotServer {
         {
           name: 'manage_layers',
           description: 'List/set named layer definitions in project',
+          tags: ['project', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2848,6 +2985,7 @@ class GodotServer {
         {
           name: 'manage_plugins',
           description: 'List/enable/disable editor plugins',
+          tags: ['project', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2861,6 +2999,7 @@ class GodotServer {
         {
           name: 'manage_shader',
           description: 'Create or read .gdshader files',
+          tags: ['shader', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2876,6 +3015,7 @@ class GodotServer {
         {
           name: 'manage_theme_resource',
           description: 'Create/read/modify Theme .tres resources',
+          tags: ['ui', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2890,6 +3030,7 @@ class GodotServer {
         {
           name: 'set_main_scene',
           description: 'Set the main scene in project.godot',
+          tags: ['project', 'scene', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2902,6 +3043,7 @@ class GodotServer {
         {
           name: 'manage_scene_structure',
           description: 'Rename/duplicate/move nodes within .tscn scenes',
+          tags: ['scene', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2918,6 +3060,7 @@ class GodotServer {
         {
           name: 'manage_translations',
           description: 'List/add/remove translation files in project',
+          tags: ['project', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2931,6 +3074,7 @@ class GodotServer {
         {
           name: 'game_locale',
           description: 'Set/get locale and translate strings at runtime',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2945,6 +3089,7 @@ class GodotServer {
         {
           name: 'game_ui_control',
           description: 'Set focus, anchors, tooltip, mouse filter on Control',
+          tags: ['runtime', 'ui'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2961,6 +3106,7 @@ class GodotServer {
         {
           name: 'game_ui_text',
           description: 'LineEdit/TextEdit/RichTextLabel text operations',
+          tags: ['runtime', 'ui'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2977,6 +3123,7 @@ class GodotServer {
         {
           name: 'game_ui_popup',
           description: 'Show/hide/popup for Popup/Dialog/Window nodes',
+          tags: ['runtime', 'ui'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2992,6 +3139,7 @@ class GodotServer {
         {
           name: 'game_ui_tree',
           description: 'Tree control: get/select/collapse/add/remove items',
+          tags: ['runtime', 'ui'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -3007,6 +3155,7 @@ class GodotServer {
         {
           name: 'game_ui_item_list',
           description: 'ItemList/OptionButton: get/select/add/remove items',
+          tags: ['runtime', 'ui'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -3021,6 +3170,7 @@ class GodotServer {
         {
           name: 'game_ui_tabs',
           description: 'TabContainer/TabBar: get/set current tab',
+          tags: ['runtime', 'ui'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -3035,6 +3185,7 @@ class GodotServer {
         {
           name: 'game_ui_menu',
           description: 'PopupMenu/MenuBar: add/remove/get menu items',
+          tags: ['runtime', 'ui'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -3051,6 +3202,7 @@ class GodotServer {
         {
           name: 'game_ui_range',
           description: 'ProgressBar/Slider/SpinBox/ColorPicker get/set',
+          tags: ['runtime', 'ui'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -3068,6 +3220,7 @@ class GodotServer {
         {
           name: 'game_render_settings',
           description: 'Get/set MSAA, FXAA, TAA, scaling mode/scale',
+          tags: ['runtime', 'rendering'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -3085,6 +3238,7 @@ class GodotServer {
         {
           name: 'game_resource',
           description: 'Runtime resource load, save, or preload',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -3100,6 +3254,7 @@ class GodotServer {
         {
           name: 'game_visual_shader',
           description: 'Create and edit VisualShader graphs: add/connect/disconnect nodes',
+          tags: ['runtime', 'shader'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -3120,6 +3275,7 @@ class GodotServer {
         {
           name: 'game_terrain',
           description: 'Create/modify terrain meshes from heightmap data',
+          tags: ['runtime', '3d'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -3143,6 +3299,7 @@ class GodotServer {
         {
           name: 'game_video',
           description: 'Video playback control: play, pause, stop, seek on VideoStreamPlayer',
+          tags: ['runtime'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -3162,6 +3319,7 @@ class GodotServer {
         {
           name: 'manage_ci_pipeline',
           description: 'Create/read GitHub Actions workflow for automated Godot exports',
+          tags: ['project', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -3176,6 +3334,7 @@ class GodotServer {
         {
           name: 'manage_docker_export',
           description: 'Create Dockerfile for headless Godot export',
+          tags: ['project', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -3188,11 +3347,25 @@ class GodotServer {
             required: ['projectPath', 'action'],
           },
         },
-      ],
+    ];
+    const enabledTools = this.toolFilter.filter(allTools);
+    if (DEBUG_MODE) {
+      console.error(
+        `[DEBUG] Tool filter: ${enabledTools.length}/${allTools.length} tools enabled`
+      );
+    }
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: enabledTools,
     }));
 
     // Handle tool calls
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      if (!this.toolFilter.isEnabled(request.params.name)) {
+        throw new McpError(
+          ErrorCode.MethodNotFound,
+          `Tool '${request.params.name}' is disabled by config`
+        );
+      }
       this.logDebug(`Handling tool request: ${request.params.name}`);
       switch (request.params.name) {
         case 'launch_editor':
@@ -6680,9 +6853,15 @@ class GodotServer {
 }
 
 // Create and run the server
-const server = new GodotServer();
-server.run().catch((error: unknown) => {
+try {
+  const server = new GodotServer();
+  server.run().catch((error: unknown) => {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('Failed to run server:', errorMessage);
+    process.exit(1);
+  });
+} catch (error: unknown) {
   const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-  console.error('Failed to run server:', errorMessage);
+  console.error('Failed to initialize server:', errorMessage);
   process.exit(1);
-});
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import {
   toNativeProjectPath,
   isWindowsGodotExe,
   projectGodotFile,
+  projectFilePath,
   toWindowsAccessiblePath,
   parseGodotIni,
   type OperationParams,
@@ -122,17 +123,15 @@ class GodotServer {
         this.strictPathValidation = config.strictPathValidation;
       }
 
-      // Store and validate custom Godot path if provided
+      // Store the custom Godot path if provided. We used to sync-validate
+      // here, but the check uses existsSync which can't resolve Windows
+      // paths from WSL Node (C:\\...) or WSL-UNC paths from Windows Node,
+      // and a failed validation quietly triggered autodetect that hid the
+      // real problem. Same trust policy as GODOT_PATH — the first real
+      // invocation surfaces any error.
       if (config.godotPath) {
-        const normalizedPath = normalize(config.godotPath);
-        this.godotPath = normalizedPath;
-        this.logDebug(`Custom Godot path provided: ${this.godotPath}`);
-
-        // Validate immediately with sync check
-        if (!this.isValidGodotPathSync(this.godotPath)) {
-          console.warn(`[SERVER] Invalid custom Godot path provided: ${this.godotPath}`);
-          this.godotPath = null; // Reset to trigger auto-detection later
-        }
+        this.godotPath = normalize(config.godotPath);
+        this.logDebug(`Custom Godot path provided (pre-validation skipped): ${this.godotPath}`);
       }
     }
 
@@ -246,8 +245,9 @@ class GodotServer {
    * Detect the Godot executable path based on the operating system
    */
   private async detectGodotPath() {
-    // If godotPath is already set and valid, use it
-    if (this.godotPath && await this.isValidGodotPath(this.godotPath)) {
+    // If godotPath is already set (from config or a prior detection), trust
+    // it. Autodetect is a fallback, not a correction step.
+    if (this.godotPath) {
       this.logDebug(`Using existing Godot path: ${this.godotPath}`);
       return;
     }
@@ -307,12 +307,10 @@ class GodotServer {
       }
     }
 
-    // If we get here, we couldn't find Godot
+    // If we get here, we couldn't find Godot. GODOT_PATH is honored above
+    // without pre-validation, so if we're in this branch it was never set.
     this.logDebug(`Warning: Could not find Godot in common locations for ${osPlatform}`);
-    const envNote = process.env.GODOT_PATH
-      ? ` (GODOT_PATH=${process.env.GODOT_PATH} did not resolve to a usable binary)`
-      : '';
-    console.error(`[SERVER] Could not find Godot in common locations for ${osPlatform}${envNote}`);
+    console.error(`[SERVER] Could not find Godot in common locations for ${osPlatform}`);
     console.error(`[SERVER] Set GODOT_PATH=/path/to/godot environment variable or pass { godotPath: '/path/to/godot' } in the config to specify the correct path.`);
 
     if (this.strictPathValidation) {
@@ -362,7 +360,7 @@ class GodotServer {
    */
   private injectInteractionServer(projectPath: string): void {
     const projectFile = projectGodotFile(projectPath);
-    const destScript = join(projectPath, 'mcp_interaction_server.gd');
+    const destScript = projectFilePath(projectPath, 'mcp_interaction_server.gd');
 
     // Copy the interaction script into the project
     copyFileSync(this.interactionScriptPath, destScript);
@@ -396,7 +394,7 @@ class GodotServer {
    */
   private removeInteractionServer(projectPath: string): void {
     const projectFile = projectGodotFile(projectPath);
-    const destScript = join(projectPath, 'mcp_interaction_server.gd');
+    const destScript = projectFilePath(projectPath, 'mcp_interaction_server.gd');
 
     // Remove autoload line from project.godot
     if (existsSync(projectFile)) {
@@ -731,22 +729,28 @@ class GodotServer {
   private findGodotProjects(directory: string, recursive: boolean): Array<{ path: string; name: string }> {
     const projects: Array<{ path: string; name: string }> = [];
 
+    // Translate user-supplied dir once so WSL Node can stat it. readdirSync
+    // needs the translated form; the returned path we report back to callers
+    // is built from the translated dir too, so downstream consumers get a
+    // path their own fs layer can resolve.
+    const fsDir = toWslProjectPath(directory);
+
     try {
       // Check if the directory itself is a Godot project
       const projectFile = projectGodotFile(directory);
       if (existsSync(projectFile)) {
         projects.push({
-          path: directory,
-          name: basename(directory),
+          path: fsDir,
+          name: basename(fsDir),
         });
       }
 
       // If not recursive, only check immediate subdirectories
       if (!recursive) {
-        const entries = readdirSync(directory, { withFileTypes: true });
+        const entries = readdirSync(fsDir, { withFileTypes: true });
         for (const entry of entries) {
           if (entry.isDirectory()) {
-            const subdir = join(directory, entry.name);
+            const subdir = join(fsDir, entry.name);
             const projectFile = projectGodotFile(subdir);
             if (existsSync(projectFile)) {
               projects.push({
@@ -758,10 +762,10 @@ class GodotServer {
         }
       } else {
         // Recursive search
-        const entries = readdirSync(directory, { withFileTypes: true });
+        const entries = readdirSync(fsDir, { withFileTypes: true });
         for (const entry of entries) {
           if (entry.isDirectory()) {
-            const subdir = join(directory, entry.name);
+            const subdir = join(fsDir, entry.name);
             // Skip hidden directories
             if (entry.name.startsWith('.')) {
               continue;
@@ -1167,7 +1171,7 @@ class GodotServer {
             required: [],
           },
         },
-{
+        {
           name: 'game_eval',
           description: 'Execute GDScript in the running game. Use "return" for values.',
           tags: ['runtime', 'gdscript-only'],
@@ -1354,7 +1358,7 @@ class GodotServer {
             required: [],
           },
         },
-{
+        {
           name: 'read_scene',
           description: 'Read scene file as JSON node tree (headless)',
           tags: ['scene', 'headless'],
@@ -1423,7 +1427,7 @@ class GodotServer {
             required: ['projectPath', 'scenePath', 'nodePath'],
           },
         },
-{
+        {
           name: 'read_project_settings',
           description: 'Read project.godot as structured JSON',
           tags: ['project', 'headless'],
@@ -1489,7 +1493,7 @@ class GodotServer {
             required: ['projectPath'],
           },
         },
-{
+        {
           name: 'game_connect_signal',
           description: 'Connect a signal from one node to a method on another node in the running game',
           tags: ['runtime', 'signal'],
@@ -1603,7 +1607,7 @@ class GodotServer {
             required: ['nodePath', 'newParentPath'],
           },
         },
-{
+        {
           name: 'attach_script',
           description: 'Attach a GDScript or C# script to a scene node (headless)',
           tags: ['script', 'headless'],
@@ -1959,8 +1963,8 @@ class GodotServer {
         },
         {
           name: 'game_navigate_path',
-          description: 'Query a navigation path between two points',
-          tags: ['runtime'],
+          description: 'Query a navigation path between two points (2D or 3D)',
+          tags: ['runtime', 'navigation'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -2392,7 +2396,6 @@ class GodotServer {
               action: { type: 'string', description: 'Action: attach, detach, get_source' },
               scriptPath: { type: 'string', description: 'Path to precompiled .gd or .cs (attach only). C# must be prebuilt.' },
               source: { type: 'string', description: 'Inline GDScript source (attach). No inline C# — use scriptPath instead.' },
-              className: { type: 'string', description: 'Class the script extends' },
             },
             required: ['nodePath', 'action'],
           },
@@ -2668,7 +2671,7 @@ class GodotServer {
         {
           name: 'game_navigation_3d',
           description: 'Create/configure NavigationRegion3D and bake',
-          tags: ['runtime', '3d'],
+          tags: ['runtime', '3d', 'navigation'],
           inputSchema: {
             type: 'object',
             properties: {
@@ -4021,7 +4024,7 @@ class GodotServer {
 
     try {
       this.logDebug(`Listing Godot projects in directory: ${args.directory}`);
-      if (!existsSync(args.directory)) {
+      if (!existsSync(toWslProjectPath(args.directory))) {
         return createErrorResponse(
           `Directory does not exist: ${args.directory}`
         );
@@ -4279,7 +4282,7 @@ class GodotServer {
       }
 
       // Check if the scene file exists
-      const scenePath = join(args.projectPath, args.scenePath);
+      const scenePath = projectFilePath(args.projectPath, args.scenePath);
       if (!existsSync(scenePath)) {
         return createErrorResponse(
           `Scene file does not exist: ${args.scenePath}`
@@ -4360,7 +4363,7 @@ class GodotServer {
       }
 
       // Check if the scene file exists
-      const scenePath = join(args.projectPath, args.scenePath);
+      const scenePath = projectFilePath(args.projectPath, args.scenePath);
       if (!existsSync(scenePath)) {
         return createErrorResponse(
           `Scene file does not exist: ${args.scenePath}`
@@ -4368,7 +4371,7 @@ class GodotServer {
       }
 
       // Check if the texture file exists
-      const texturePath = join(args.projectPath, args.texturePath);
+      const texturePath = projectFilePath(args.projectPath, args.texturePath);
       if (!existsSync(texturePath)) {
         return createErrorResponse(
           `Texture file does not exist: ${args.texturePath}`
@@ -4439,7 +4442,7 @@ class GodotServer {
       }
 
       // Check if the scene file exists
-      const scenePath = join(args.projectPath, args.scenePath);
+      const scenePath = projectFilePath(args.projectPath, args.scenePath);
       if (!existsSync(scenePath)) {
         return createErrorResponse(
           `Scene file does not exist: ${args.scenePath}`
@@ -4517,7 +4520,7 @@ class GodotServer {
       }
 
       // Check if the scene file exists
-      const scenePath = join(args.projectPath, args.scenePath);
+      const scenePath = projectFilePath(args.projectPath, args.scenePath);
       if (!existsSync(scenePath)) {
         return createErrorResponse(
           `Scene file does not exist: ${args.scenePath}`
@@ -4598,7 +4601,7 @@ class GodotServer {
       }
 
       // Check if the file exists
-      const filePath = join(args.projectPath, args.filePath);
+      const filePath = projectFilePath(args.projectPath, args.filePath);
       if (!existsSync(filePath)) {
         return createErrorResponse(
           `File does not exist: ${args.filePath}`
@@ -4629,23 +4632,39 @@ class GodotServer {
         );
       }
 
-      // Godot prints its engine banner before any script output, so we can't
-      // just trim stdout. UIDs always start with uid://.
-      const uidMatch = stdout.match(/uid:\/\/[a-z0-9]+/i);
-      if (!uidMatch) {
-        return createErrorResponse(
-          `No UID found for ${args.filePath}. Godot stdout: ${stdout.trim() || '(empty)'}`
-        );
+      // The GDScript side emits a single JSON object on stdout, after the
+      // Godot engine banner. Find the last balanced {...} and parse it so
+      // we don't confuse ourselves with banner text that incidentally
+      // contains characters.
+      const parsed = extractTrailingJson(stdout);
+      if (parsed && typeof parsed === 'object') {
+        if (parsed.exists && typeof parsed.uid === 'string') {
+          return {
+            content: [
+              { type: 'text', text: `UID for ${args.filePath}: ${parsed.uid}` },
+            ],
+          };
+        }
+        if (parsed.exists === false) {
+          const hint = parsed.message
+            ? String(parsed.message)
+            : 'No UID found. If the file is a .cs/.gd, Godot 4.4+ writes a sidecar .uid file when the project is imported; run the editor once or use resave_resources.';
+          return createErrorResponse(`No UID for ${args.filePath}: ${hint}`);
+        }
       }
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `UID for ${args.filePath}: ${uidMatch[0]}`,
-          },
-        ],
-      };
+      // Legacy / defensive fallback: a bare uid://... somewhere in stdout.
+      const uidMatch = stdout.match(/uid:\/\/[a-z0-9]+/i);
+      if (uidMatch) {
+        return {
+          content: [
+            { type: 'text', text: `UID for ${args.filePath}: ${uidMatch[0]}` },
+          ],
+        };
+      }
+      return createErrorResponse(
+        `No UID found for ${args.filePath}. Godot stdout: ${stdout.trim() || '(empty)'}`
+      );
     } catch (error: any) {
       return createErrorResponse(
         `Failed to get UID: ${error?.message || 'Unknown error'}`
@@ -4801,7 +4820,7 @@ class GodotServer {
       return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     }
 
-    const scenePath = join(args.projectPath, args.scenePath);
+    const scenePath = projectFilePath(args.projectPath, args.scenePath);
     if (!existsSync(scenePath)) {
       return createErrorResponse(`Scene file does not exist: ${args.scenePath}`);
     }
@@ -4963,13 +4982,13 @@ class GodotServer {
       return createErrorResponse('Invalid path.');
     }
 
-    if (!existsSync(args.projectPath)) {
+    if (!existsSync(toWslProjectPath(args.projectPath))) {
       return createErrorResponse(`Directory does not exist: ${args.projectPath}`);
     }
 
     try {
       const baseDir = args.subdirectory
-        ? join(args.projectPath, args.subdirectory)
+        ? projectFilePath(args.projectPath, args.subdirectory)
         : args.projectPath;
 
       if (!existsSync(baseDir)) {
@@ -5108,7 +5127,7 @@ class GodotServer {
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
       return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
-    const fullPath = join(args.projectPath, args.filePath);
+    const fullPath = projectFilePath(args.projectPath, args.filePath);
     if (!existsSync(fullPath))
       return createErrorResponse(`File does not exist: ${args.filePath}`);
     try {
@@ -5129,7 +5148,7 @@ class GodotServer {
     if (!existsSync(projectFile))
       return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     try {
-      const fullPath = join(args.projectPath, args.filePath);
+      const fullPath = projectFilePath(args.projectPath, args.filePath);
       const parentDir = dirname(fullPath);
       if (!existsSync(parentDir)) {
         mkdirSync(parentDir, { recursive: true });
@@ -5150,7 +5169,7 @@ class GodotServer {
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
       return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
-    const fullPath = join(args.projectPath, args.filePath);
+    const fullPath = projectFilePath(args.projectPath, args.filePath);
     if (!existsSync(fullPath))
       return createErrorResponse(`File does not exist: ${args.filePath}`);
     try {
@@ -5171,7 +5190,7 @@ class GodotServer {
     if (!existsSync(projectFile))
       return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     try {
-      const fullPath = join(args.projectPath, args.directoryPath);
+      const fullPath = projectFilePath(args.projectPath, args.directoryPath);
       mkdirSync(fullPath, { recursive: true });
       return { content: [{ type: 'text', text: `Directory created: ${args.directoryPath}` }] };
     } catch (error: any) {
@@ -5251,8 +5270,9 @@ class GodotServer {
     if (!validatePath(args.projectPath))
       return createErrorResponse('Invalid path.');
     try {
-      if (!existsSync(args.projectPath)) {
-        mkdirSync(args.projectPath, { recursive: true });
+      const fsProjectPath = toWslProjectPath(args.projectPath);
+      if (!existsSync(fsProjectPath)) {
+        mkdirSync(fsProjectPath, { recursive: true });
       }
       const projectFile = projectGodotFile(args.projectPath);
       if (existsSync(projectFile))
@@ -5382,7 +5402,7 @@ class GodotServer {
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile))
       return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
-    const presetsFile = join(args.projectPath, 'export_presets.cfg');
+    const presetsFile = projectFilePath(args.projectPath, 'export_presets.cfg');
     try {
       if (args.action === 'list') {
         if (!existsSync(presetsFile))
@@ -5627,7 +5647,10 @@ class GodotServer {
     }
     try {
       const exportFlag = args.debug ? '--export-debug' : '--export-release';
-      const exportArgs = ['--headless', '--path', this.godotSpawnPath(args.projectPath), exportFlag, args.presetName, args.outputPath];
+      // outputPath is resolved relative to the project when not absolute;
+      // translate to a Godot-accessible form so Windows Godot can write it.
+      const nativeOutput = toWindowsAccessiblePath(args.outputPath, this.godotPath);
+      const exportArgs = ['--headless', '--path', this.godotSpawnPath(args.projectPath), exportFlag, args.presetName, nativeOutput];
       const { stdout, stderr } = await execFileAsync(this.godotPath!, exportArgs, { timeout: 120000 });
       if (stderr && stderr.includes('ERROR'))
         return createErrorResponse(`Export failed: ${stderr}`);
@@ -5842,7 +5865,6 @@ class GodotServer {
       node_path: a.nodePath, action: a.action,
       ...(a.scriptPath ? { script_path: a.scriptPath } : {}),
       ...(a.source ? { source: a.source } : {}),
-      ...(a.className ? { class_name: a.className } : {}),
     }));
   }
 
@@ -6234,8 +6256,8 @@ class GodotServer {
     if (!validatePath(args.projectPath) || !validatePath(args.filePath) || !validatePath(args.newPath)) return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
-    const srcFull = join(args.projectPath, args.filePath);
-    const dstFull = join(args.projectPath, args.newPath);
+    const srcFull = projectFilePath(args.projectPath, args.filePath);
+    const dstFull = projectFilePath(args.projectPath, args.newPath);
     if (!existsSync(srcFull)) return createErrorResponse(`File not found: ${args.filePath}`);
     try {
       const dstDir = dirname(dstFull);
@@ -6263,7 +6285,7 @@ class GodotServer {
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
     try {
-      const fullPath = join(args.projectPath, args.scriptPath);
+      const fullPath = projectFilePath(args.projectPath, args.scriptPath);
       const dir = dirname(fullPath);
       if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
       const isCSharp = args.scriptPath.toLowerCase().endsWith('.cs');
@@ -6355,7 +6377,7 @@ class GodotServer {
         while ((match = pluginRegex.exec(content)) !== null) {
           plugins.push(match[1]);
         }
-        const addonsDir = join(args.projectPath, 'addons');
+        const addonsDir = projectFilePath(args.projectPath, 'addons');
         const available: string[] = [];
         if (existsSync(addonsDir)) {
           const entries = readdirSync(addonsDir, { withFileTypes: true });
@@ -6390,7 +6412,7 @@ class GodotServer {
     if (!validatePath(args.projectPath) || !validatePath(args.shaderPath)) return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
-    const fullPath = join(args.projectPath, args.shaderPath);
+    const fullPath = projectFilePath(args.projectPath, args.shaderPath);
     try {
       if (args.action === 'read') {
         if (!existsSync(fullPath)) return createErrorResponse(`Shader not found: ${args.shaderPath}`);
@@ -6687,7 +6709,7 @@ class GodotServer {
     if (!validatePath(args.projectPath)) return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
-    const workflowDir = join(args.projectPath, '.github', 'workflows');
+    const workflowDir = projectFilePath(args.projectPath, '.github', 'workflows');
     const workflowPath = join(workflowDir, 'godot-export.yml');
     try {
       if (args.action === 'read') {
@@ -6715,7 +6737,7 @@ class GodotServer {
     if (!validatePath(args.projectPath)) return createErrorResponse('Invalid path.');
     const projectFile = projectGodotFile(args.projectPath);
     if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
-    const dockerfilePath = join(args.projectPath, 'Dockerfile');
+    const dockerfilePath = projectFilePath(args.projectPath, 'Dockerfile');
     try {
       if (args.action === 'read') {
         if (!existsSync(dockerfilePath)) return createErrorResponse('No Dockerfile found in project root.');
@@ -6853,6 +6875,53 @@ class GodotServer {
       console.error('[SERVER] Failed to start:', errorMessage);
       process.exit(1);
     }
+  }
+}
+
+/**
+ * Scan a Godot stdout blob for the last balanced JSON object and parse it.
+ * Returns `null` when no syntactically valid object is found — callers fall
+ * back to legacy parsing or emit a clean error.
+ *
+ * We walk backwards from the last `}` so the Godot engine banner printed
+ * before the script's JSON output doesn't confuse the matcher.
+ */
+function extractTrailingJson(blob: string): any {
+  const end = blob.lastIndexOf('}');
+  if (end === -1) return null;
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  let start = -1;
+  for (let i = end; i >= 0; i--) {
+    const ch = blob[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === '\\' && inString) {
+      escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === '}') depth++;
+    else if (ch === '{') {
+      depth--;
+      if (depth === 0) {
+        start = i;
+        break;
+      }
+    }
+  }
+  if (start === -1) return null;
+  try {
+    return JSON.parse(blob.slice(start, end + 1));
+  } catch {
+    return null;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4563,6 +4563,31 @@ class GodotServer {
   }
 
   /**
+   * Extract a UID from a get_uid operation's stdout. Returns the UID string
+   * when found, an object with a `hint` when the script reported no UID, or
+   * null when the output is unparseable.
+   *
+   * The GDScript side emits a single JSON object after the Godot banner. We
+   * also accept a bare `uid://…` match as a defensive fallback for older
+   * dispatcher builds that might emit plain text.
+   */
+  private pickUidFromStdout(stdout: string): string | { hint: string } | null {
+    const parsed = extractTrailingJson(stdout);
+    if (parsed && typeof parsed === 'object') {
+      if (parsed.exists && typeof parsed.uid === 'string') return parsed.uid;
+      if (parsed.exists === false) {
+        return {
+          hint: parsed.message
+            ? String(parsed.message)
+            : 'No UID found. If the file is a .cs/.gd, Godot 4.4+ writes a sidecar .uid file when the project is imported; run the editor once or use resave_resources.',
+        };
+      }
+    }
+    const uidMatch = stdout.match(/uid:\/\/[a-z0-9]+/i);
+    return uidMatch ? uidMatch[0] : null;
+  }
+
+  /**
    * Handle the get_uid tool
    */
   private async handleGetUid(args: any) {
@@ -4632,35 +4657,12 @@ class GodotServer {
         );
       }
 
-      // The GDScript side emits a single JSON object on stdout, after the
-      // Godot engine banner. Find the last balanced {...} and parse it so
-      // we don't confuse ourselves with banner text that incidentally
-      // contains characters.
-      const parsed = extractTrailingJson(stdout);
-      if (parsed && typeof parsed === 'object') {
-        if (parsed.exists && typeof parsed.uid === 'string') {
-          return {
-            content: [
-              { type: 'text', text: `UID for ${args.filePath}: ${parsed.uid}` },
-            ],
-          };
-        }
-        if (parsed.exists === false) {
-          const hint = parsed.message
-            ? String(parsed.message)
-            : 'No UID found. If the file is a .cs/.gd, Godot 4.4+ writes a sidecar .uid file when the project is imported; run the editor once or use resave_resources.';
-          return createErrorResponse(`No UID for ${args.filePath}: ${hint}`);
-        }
+      const picked = this.pickUidFromStdout(stdout);
+      if (typeof picked === 'string') {
+        return { content: [{ type: 'text', text: `UID for ${args.filePath}: ${picked}` }] };
       }
-
-      // Legacy / defensive fallback: a bare uid://... somewhere in stdout.
-      const uidMatch = stdout.match(/uid:\/\/[a-z0-9]+/i);
-      if (uidMatch) {
-        return {
-          content: [
-            { type: 'text', text: `UID for ${args.filePath}: ${uidMatch[0]}` },
-          ],
-        };
+      if (picked && typeof picked === 'object') {
+        return createErrorResponse(`No UID for ${args.filePath}: ${picked.hint}`);
       }
       return createErrorResponse(
         `No UID found for ${args.filePath}. Godot stdout: ${stdout.trim() || '(empty)'}`
@@ -6879,50 +6881,47 @@ class GodotServer {
 }
 
 /**
- * Scan a Godot stdout blob for the last balanced JSON object and parse it.
- * Returns `null` when no syntactically valid object is found — callers fall
- * back to legacy parsing or emit a clean error.
+ * Scan a Godot stdout blob for the first balanced JSON object and parse it.
+ * Returns `null` when no syntactically valid object is found.
  *
- * We walk backwards from the last `}` so the Godot engine banner printed
- * before the script's JSON output doesn't confuse the matcher.
+ * Godot's engine banner contains no `{`, so the first `{` in stdout reliably
+ * starts the script's own JSON payload. We scan forward so string-escape
+ * tracking works naturally (backwards scanning would encounter the escaped
+ * character before the backslash that escapes it).
  */
 function extractTrailingJson(blob: string): any {
-  const end = blob.lastIndexOf('}');
-  if (end === -1) return null;
+  const start = blob.indexOf('{');
+  if (start === -1) return null;
   let depth = 0;
   let inString = false;
-  let escape = false;
-  let start = -1;
-  for (let i = end; i >= 0; i--) {
+  for (let i = start; i < blob.length; i++) {
     const ch = blob[i];
-    if (escape) {
-      escape = false;
-      continue;
-    }
-    if (ch === '\\' && inString) {
-      escape = true;
+    if (inString) {
+      if (ch === '\\') {
+        // Skip the escaped character.
+        i++;
+        continue;
+      }
+      if (ch === '"') inString = false;
       continue;
     }
     if (ch === '"') {
-      inString = !inString;
+      inString = true;
       continue;
     }
-    if (inString) continue;
-    if (ch === '}') depth++;
-    else if (ch === '{') {
+    if (ch === '{') depth++;
+    else if (ch === '}') {
       depth--;
       if (depth === 0) {
-        start = i;
-        break;
+        try {
+          return JSON.parse(blob.slice(start, i + 1));
+        } catch {
+          return null;
+        }
       }
     }
   }
-  if (start === -1) return null;
-  try {
-    return JSON.parse(blob.slice(start, end + 1));
-  } catch {
-    return null;
-  }
+  return null;
 }
 
 // Create and run the server

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ import {
   convertCamelToSnakeCase,
   validatePath,
   createErrorResponse,
+  addGodotIniSectionLine,
+  removeGodotIniSectionLine,
   isGodot44OrLater,
   toWslProjectPath,
   toNativeProjectPath,
@@ -373,22 +375,20 @@ class GodotServer {
     // Add autoload entry to project.godot
     let content = readFileSync(projectFile, 'utf8');
 
-    // Check if already injected
-    if (content.includes(this.AUTOLOAD_NAME)) {
+    const autoloadLine = `${this.AUTOLOAD_NAME}="*res://mcp_interaction_server.gd"`;
+
+    const updatedContent = addGodotIniSectionLine(
+      content,
+      'autoload',
+      autoloadLine,
+      this.AUTOLOAD_NAME
+    );
+    if (updatedContent === content) {
       this.logDebug('Interaction server autoload already present');
       return;
     }
 
-    const autoloadLine = `${this.AUTOLOAD_NAME}="*res://mcp_interaction_server.gd"`;
-
-    if (content.includes('[autoload]')) {
-      // Add after existing [autoload] section header
-      content = content.replace('[autoload]', `[autoload]\n\n${autoloadLine}`);
-    } else {
-      // Add new [autoload] section at end
-      content += `\n[autoload]\n\n${autoloadLine}\n`;
-    }
-
+    content = updatedContent;
     writeFileSync(projectFile, content, 'utf8');
     this.logDebug(`Injected ${this.AUTOLOAD_NAME} autoload into project.godot`);
   }
@@ -403,9 +403,7 @@ class GodotServer {
     // Remove autoload line from project.godot
     if (existsSync(projectFile)) {
       let content = readFileSync(projectFile, 'utf8');
-      // Remove the autoload line (and any surrounding blank line)
-      const autoloadLine = `${this.AUTOLOAD_NAME}="*res://mcp_interaction_server.gd"`;
-      content = content.replace(new RegExp(`\\n?${autoloadLine.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\n?`), '\n');
+      content = removeGodotIniSectionLine(content, 'autoload', this.AUTOLOAD_NAME);
       writeFileSync(projectFile, content, 'utf8');
       this.logDebug('Removed interaction server autoload from project.godot');
     }
@@ -5456,18 +5454,13 @@ class GodotServer {
         if (!args.name || !args.path)
           return createErrorResponse('name and path are required for add action.');
         const autoloadLine = `${args.name}="*${args.path}"`;
-        if (content.includes('[autoload]')) {
-          content = content.replace('[autoload]', `[autoload]\n\n${autoloadLine}`);
-        } else {
-          content += `\n[autoload]\n\n${autoloadLine}\n`;
-        }
+        content = addGodotIniSectionLine(content, 'autoload', autoloadLine, args.name);
         writeFileSync(projectFile, content, 'utf8');
         return { content: [{ type: 'text', text: `Autoload "${args.name}" added: ${args.path}` }] };
       } else if (args.action === 'remove') {
         if (!args.name)
           return createErrorResponse('name is required for remove action.');
-        const pattern = new RegExp(`\\n?${args.name}\\s*=.*\\n?`, 'g');
-        content = content.replace(pattern, '\n');
+        content = removeGodotIniSectionLine(content, 'autoload', args.name);
         writeFileSync(projectFile, content, 'utf8');
         return { content: [{ type: 'text', text: `Autoload "${args.name}" removed.` }] };
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -874,6 +874,21 @@ class GodotServer {
           },
         },
         {
+          name: 'build_project',
+          description: 'Headless editor pass that builds C# solutions and regenerates .uid files',
+          tags: ['editor', 'csharp'],
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: {
+                type: 'string',
+                description: 'Godot project path',
+              },
+            },
+            required: ['projectPath'],
+          },
+        },
+        {
           name: 'run_project',
           description: 'Run the Godot project and capture output',
           tags: ['editor', 'runtime'],
@@ -3452,6 +3467,8 @@ class GodotServer {
       switch (request.params.name) {
         case 'launch_editor':
           return await this.handleLaunchEditor(request.params.arguments);
+        case 'build_project':
+          return await this.handleBuildProject(request.params.arguments);
         case 'run_project':
           return await this.handleRunProject(request.params.arguments);
         case 'get_debug_output':
@@ -3845,6 +3862,66 @@ class GodotServer {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       return createErrorResponse(
         `Failed to launch Godot editor: ${errorMessage}`
+      );
+    }
+  }
+
+  /**
+   * Handle the build_project tool — headless editor run that builds C# solutions
+   * and (as a side effect of the editor startup) re-imports the project, which
+   * regenerates .uid sidecars for newly added scripts. Runs to completion and
+   * returns captured stdout/stderr.
+   */
+  private async handleBuildProject(args: any) {
+    args = normalizeParameters(args);
+    if (!args.projectPath) return createErrorResponse('Project path is required');
+    if (!validatePath(args.projectPath)) return createErrorResponse('Invalid project path');
+
+    try {
+      if (!this.godotPath) {
+        await this.detectGodotPath();
+        if (!this.godotPath) return createErrorResponse('Could not find a valid Godot executable path');
+      }
+
+      const projectFile = projectGodotFile(args.projectPath);
+      if (!existsSync(projectFile)) {
+        return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
+      }
+
+      // --build-solutions implies --editor and builds C# solutions via MSBuild.
+      // --quit-after 2 guarantees the editor exits after the build/import pass
+      // even if Godot's own "exit when done" behaviour changes across versions.
+      const cmdArgs = [
+        '--headless',
+        '--build-solutions',
+        '--quit-after', '2',
+        '--path', this.godotSpawnPath(args.projectPath),
+      ];
+
+      this.logDebug(`Building Godot project: ${this.godotPath} ${cmdArgs.join(' ')}`);
+      const { stdout, stderr } = await execFileAsync(this.godotPath!, cmdArgs, {
+        timeout: 300_000,
+        maxBuffer: 16 * 1024 * 1024,
+      });
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              message: 'Build completed',
+              stdout: stdout.split('\n'),
+              stderr: stderr.split('\n'),
+            }, null, 2),
+          },
+        ],
+      };
+    } catch (error: any) {
+      const stdout = typeof error?.stdout === 'string' ? error.stdout : '';
+      const stderr = typeof error?.stderr === 'string' ? error.stderr : '';
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      return createErrorResponse(
+        `Build failed: ${msg}\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`
       );
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import {
   type OperationParams,
 } from './utils.js';
 import { ToolFilter, type ToolDef } from './tool-filter.js';
+import { buildGdScriptTemplate, buildCSharpScriptTemplate } from './script-templates.js';
 
 // Check if debug mode is enabled
 const DEBUG_MODE: boolean = process.env.DEBUG === 'true';
@@ -1587,15 +1588,15 @@ class GodotServer {
         },
 {
           name: 'attach_script',
-          description: 'Attach a GDScript to a scene node (headless)',
-          tags: ['script', 'gdscript-only', 'headless'],
+          description: 'Attach a GDScript or C# script to a scene node (headless)',
+          tags: ['script', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
               projectPath: { type: 'string', description: 'Godot project path' },
               scenePath: { type: 'string', description: 'Scene file path (relative to project)' },
               nodePath: { type: 'string', description: 'Path to the node within the scene (e.g., "root/Player")' },
-              scriptPath: { type: 'string', description: 'Path to the .gd script file (relative to project)' },
+              scriptPath: { type: 'string', description: 'Script path (.gd or .cs) relative to project. C# must be prebuilt.' },
             },
             required: ['projectPath', 'scenePath', 'nodePath', 'scriptPath'],
           },
@@ -2365,14 +2366,15 @@ class GodotServer {
         },
         {
           name: 'game_script',
-          description: 'Attach, detach, or get source of node scripts',
-          tags: ['runtime', 'script', 'gdscript-only'],
+          description: 'Attach, detach, or read source of node scripts (GDScript or C#)',
+          tags: ['runtime', 'script'],
           inputSchema: {
             type: 'object',
             properties: {
               nodePath: { type: 'string', description: 'Path to the node' },
               action: { type: 'string', description: 'Action: attach, detach, get_source' },
-              source: { type: 'string', description: 'GDScript source code (for attach)' },
+              scriptPath: { type: 'string', description: 'Path to precompiled .gd or .cs (attach only). C# must be prebuilt.' },
+              source: { type: 'string', description: 'Inline GDScript source (attach). No inline C# — use scriptPath instead.' },
               className: { type: 'string', description: 'Class the script extends' },
             },
             required: ['nodePath', 'action'],
@@ -2933,15 +2935,15 @@ class GodotServer {
         },
         {
           name: 'create_script',
-          description: 'Create a GDScript file from a template',
-          tags: ['script', 'gdscript-only', 'headless'],
+          description: 'Create a GDScript (.gd) or C# (.cs) script file from a template',
+          tags: ['script', 'headless'],
           inputSchema: {
             type: 'object',
             properties: {
               projectPath: { type: 'string', description: 'Godot project path' },
-              scriptPath: { type: 'string', description: 'Script file path (relative to project)' },
-              extends: { type: 'string', description: 'Base class to extend. Default: Node' },
-              className: { type: 'string', description: 'Optional class_name' },
+              scriptPath: { type: 'string', description: 'Script path (.gd or .cs) relative to project. Language inferred from extension.' },
+              extends: { type: 'string', description: 'Base class. Default: Node' },
+              className: { type: 'string', description: 'Optional class_name (.gd) / required for .cs (defaults to filename)' },
               methods: { type: 'array', description: 'Method stubs to include' },
               source: { type: 'string', description: 'Full source code (overrides template)' },
             },
@@ -5838,8 +5840,12 @@ class GodotServer {
   private async handleGameScript(args: any) {
     args = normalizeParameters(args || {});
     if (!args.nodePath || !args.action) return createErrorResponse('nodePath and action are required.');
+    if (args.action === 'attach' && !args.scriptPath && !args.source) {
+      return createErrorResponse('attach requires either scriptPath (precompiled .gd/.cs) or source (inline GDScript).');
+    }
     return this.gameCommand('script', args, a => ({
       node_path: a.nodePath, action: a.action,
+      ...(a.scriptPath ? { script_path: a.scriptPath } : {}),
       ...(a.source ? { source: a.source } : {}),
       ...(a.className ? { class_name: a.className } : {}),
     }));
@@ -6265,18 +6271,21 @@ class GodotServer {
       const fullPath = join(args.projectPath, args.scriptPath);
       const dir = dirname(fullPath);
       if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+      const isCSharp = args.scriptPath.toLowerCase().endsWith('.cs');
       let source = args.source;
       if (!source) {
-        const ext = args.extends || 'Node';
-        const lines = [`extends ${ext}`, ''];
-        if (args.className) lines.splice(1, 0, `class_name ${args.className}`);
-        if (args.methods && Array.isArray(args.methods)) {
-          for (const m of args.methods) {
-            lines.push('', `func ${m}():`);
-            lines.push('\tpass');
-          }
-        }
-        source = lines.join('\n') + '\n';
+        source = isCSharp
+          ? buildCSharpScriptTemplate({
+              scriptPath: args.scriptPath,
+              baseClass: args.extends,
+              className: args.className,
+              methods: Array.isArray(args.methods) ? args.methods : [],
+            })
+          : buildGdScriptTemplate({
+              baseClass: args.extends,
+              className: args.className,
+              methods: Array.isArray(args.methods) ? args.methods : [],
+            });
       }
       writeFileSync(fullPath, source, 'utf8');
       return { content: [{ type: 'text', text: `Script created at ${args.scriptPath}` }] };

--- a/src/script-templates.ts
+++ b/src/script-templates.ts
@@ -18,21 +18,26 @@ export interface CSharpScriptTemplateArgs extends GdScriptTemplateArgs {
 }
 
 // Godot 4 C# lifecycle methods. When a requested method name normalizes to one
-// of these, we emit an `override` with the documented signature.
+// of these, we emit an `override` with the documented signature. Keys are the
+// method name lowercased and stripped of underscores so both snake_case and
+// camelCase requests land on the same entry.
 const CSHARP_LIFECYCLE_OVERRIDES: Record<string, { pascal: string; signature: string }> = {
   _ready: { pascal: '_Ready', signature: '' },
   _process: { pascal: '_Process', signature: 'double delta' },
   _physicsprocess: { pascal: '_PhysicsProcess', signature: 'double delta' },
-  _physics_process: { pascal: '_PhysicsProcess', signature: 'double delta' },
   _input: { pascal: '_Input', signature: 'InputEvent @event' },
   _unhandledinput: { pascal: '_UnhandledInput', signature: 'InputEvent @event' },
-  _unhandled_input: { pascal: '_UnhandledInput', signature: 'InputEvent @event' },
+  _unhandledkeyinput: { pascal: '_UnhandledKeyInput', signature: 'InputEvent @event' },
+  _shortcutinput: { pascal: '_ShortcutInput', signature: 'InputEvent @event' },
+  _guiinput: { pascal: '_GuiInput', signature: 'InputEvent @event' },
   _entertree: { pascal: '_EnterTree', signature: '' },
-  _enter_tree: { pascal: '_EnterTree', signature: '' },
   _exittree: { pascal: '_ExitTree', signature: '' },
-  _exit_tree: { pascal: '_ExitTree', signature: '' },
   _notification: { pascal: '_Notification', signature: 'int what' },
   _draw: { pascal: '_Draw', signature: '' },
+  _integrateforces: { pascal: '_IntegrateForces', signature: 'PhysicsDirectBodyState3D state' },
+  _get: { pascal: '_Get', signature: 'StringName property' },
+  _set: { pascal: '_Set', signature: 'StringName property, Variant value' },
+  _getpropertylist: { pascal: '_GetPropertyList', signature: '' },
 };
 
 export function buildGdScriptTemplate(a: GdScriptTemplateArgs): string {
@@ -62,26 +67,39 @@ export function buildCSharpScriptTemplate(a: CSharpScriptTemplateArgs): string {
 }
 
 function renderCSharpMethod(name: string): string {
-  const key = name.toLowerCase();
+  const key = normalizeLifecycleKey(name);
   const override = CSHARP_LIFECYCLE_OVERRIDES[key];
   if (override) {
     return `public override void ${override.pascal}(${override.signature})\n{\n}`;
   }
-  const normalized = name.startsWith('_')
-    ? '_' + capitalize(name.slice(1))
-    : capitalize(name);
-  return `public void ${normalized}()\n{\n}`;
+  const leading = name.startsWith('_') ? '_' : '';
+  const rest = name.replace(/^_+/, '');
+  return `public void ${leading}${toPascalCase(rest)}()\n{\n}`;
+}
+
+function normalizeLifecycleKey(name: string): string {
+  return '_' + name.toLowerCase().replace(/[^a-z0-9]/g, '');
 }
 
 function capitalize(s: string): string {
   return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
 }
 
+// Convert snake_case / kebab-case / mixed input to PascalCase, preserving any
+// embedded digit runs. Empty input yields empty.
+function toPascalCase(s: string): string {
+  return s
+    .split(/[^A-Za-z0-9]+/)
+    .filter((seg) => seg.length > 0)
+    .map(capitalize)
+    .join('');
+}
+
 function sanitizeCSharpIdentifier(s: string): string {
-  let cleaned = s.replace(/[^A-Za-z0-9_]/g, '_');
-  if (/^[0-9]/.test(cleaned)) cleaned = '_' + cleaned;
-  if (cleaned.length === 0) cleaned = 'Script';
-  return capitalize(cleaned);
+  const pascal = toPascalCase(s);
+  if (pascal.length === 0) return 'Script';
+  // C# identifiers can't start with a digit.
+  return /^[0-9]/.test(pascal) ? '_' + pascal : pascal;
 }
 
 function indentLines(text: string, spaces: number): string {

--- a/src/script-templates.ts
+++ b/src/script-templates.ts
@@ -1,0 +1,93 @@
+/**
+ * Templates used by the create_script tool.
+ *
+ * GDScript and C# are supported; the language is chosen by the caller
+ * (the tool handler selects based on the target file extension).
+ */
+
+import { basename } from 'path';
+
+export interface GdScriptTemplateArgs {
+  baseClass?: string;
+  className?: string;
+  methods: string[];
+}
+
+export interface CSharpScriptTemplateArgs extends GdScriptTemplateArgs {
+  scriptPath: string;
+}
+
+// Godot 4 C# lifecycle methods. When a requested method name normalizes to one
+// of these, we emit an `override` with the documented signature.
+const CSHARP_LIFECYCLE_OVERRIDES: Record<string, { pascal: string; signature: string }> = {
+  _ready: { pascal: '_Ready', signature: '' },
+  _process: { pascal: '_Process', signature: 'double delta' },
+  _physicsprocess: { pascal: '_PhysicsProcess', signature: 'double delta' },
+  _physics_process: { pascal: '_PhysicsProcess', signature: 'double delta' },
+  _input: { pascal: '_Input', signature: 'InputEvent @event' },
+  _unhandledinput: { pascal: '_UnhandledInput', signature: 'InputEvent @event' },
+  _unhandled_input: { pascal: '_UnhandledInput', signature: 'InputEvent @event' },
+  _entertree: { pascal: '_EnterTree', signature: '' },
+  _enter_tree: { pascal: '_EnterTree', signature: '' },
+  _exittree: { pascal: '_ExitTree', signature: '' },
+  _exit_tree: { pascal: '_ExitTree', signature: '' },
+  _notification: { pascal: '_Notification', signature: 'int what' },
+  _draw: { pascal: '_Draw', signature: '' },
+};
+
+export function buildGdScriptTemplate(a: GdScriptTemplateArgs): string {
+  const ext = a.baseClass || 'Node';
+  const lines: string[] = [];
+  if (a.className) lines.push(`class_name ${a.className}`);
+  lines.push(`extends ${ext}`, '');
+  for (const m of a.methods) {
+    lines.push(`func ${m}():`, '\tpass', '');
+  }
+  return lines.join('\n');
+}
+
+export function buildCSharpScriptTemplate(a: CSharpScriptTemplateArgs): string {
+  const baseClass = a.baseClass || 'Node';
+  const fileBase = basename(a.scriptPath).replace(/\.cs$/i, '');
+  const className = a.className || sanitizeCSharpIdentifier(fileBase);
+  const methodBlocks = a.methods.map(renderCSharpMethod);
+  const body = methodBlocks.length > 0 ? methodBlocks.join('\n\n') : '';
+  return (
+    `using Godot;\n\n` +
+    `public partial class ${className} : ${baseClass}\n` +
+    `{\n` +
+    (body ? indentLines(body, 4) + '\n' : '') +
+    `}\n`
+  );
+}
+
+function renderCSharpMethod(name: string): string {
+  const key = name.toLowerCase();
+  const override = CSHARP_LIFECYCLE_OVERRIDES[key];
+  if (override) {
+    return `public override void ${override.pascal}(${override.signature})\n{\n}`;
+  }
+  const normalized = name.startsWith('_')
+    ? '_' + capitalize(name.slice(1))
+    : capitalize(name);
+  return `public void ${normalized}()\n{\n}`;
+}
+
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
+}
+
+function sanitizeCSharpIdentifier(s: string): string {
+  let cleaned = s.replace(/[^A-Za-z0-9_]/g, '_');
+  if (/^[0-9]/.test(cleaned)) cleaned = '_' + cleaned;
+  if (cleaned.length === 0) cleaned = 'Script';
+  return capitalize(cleaned);
+}
+
+function indentLines(text: string, spaces: number): string {
+  const pad = ' '.repeat(spaces);
+  return text
+    .split('\n')
+    .map((line) => (line.length === 0 ? line : pad + line))
+    .join('\n');
+}

--- a/src/script-templates.ts
+++ b/src/script-templates.ts
@@ -5,7 +5,7 @@
  * (the tool handler selects based on the target file extension).
  */
 
-import { basename } from 'path';
+import { basename } from 'node:path';
 
 export interface GdScriptTemplateArgs {
   baseClass?: string;
@@ -78,7 +78,7 @@ function renderCSharpMethod(name: string): string {
 }
 
 function normalizeLifecycleKey(name: string): string {
-  return '_' + name.toLowerCase().replace(/[^a-z0-9]/g, '');
+  return '_' + name.toLowerCase().replaceAll(/[^a-z\d]/g, '');
 }
 
 function capitalize(s: string): string {
@@ -99,7 +99,7 @@ function sanitizeCSharpIdentifier(s: string): string {
   const pascal = toPascalCase(s);
   if (pascal.length === 0) return 'Script';
   // C# identifiers can't start with a digit.
-  return /^[0-9]/.test(pascal) ? '_' + pascal : pascal;
+  return /^\d/.test(pascal) ? '_' + pascal : pascal;
 }
 
 function indentLines(text: string, spaces: number): string {

--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -89,6 +89,8 @@ func _init():
             manage_theme_resource(params)
         "manage_scene_structure":
             manage_scene_structure(params)
+        "get_scene_warnings":
+            get_scene_warnings(params)
         _:
             log_error("Unknown operation: " + operation)
             quit(1)
@@ -1434,6 +1436,69 @@ func _walk_scene_tree(node) -> Dictionary:
         info["children"] = children_arr
 
     return info
+
+# Read a scene file and collect editor configuration warnings per node
+func get_scene_warnings(params):
+    if not params.has("scene_path"):
+        printerr("scene_path is required")
+        quit(1)
+
+    var full_scene_path = params.scene_path
+    if not full_scene_path.begins_with("res://"):
+        full_scene_path = "res://" + full_scene_path
+
+    log_info("Collecting scene warnings: " + full_scene_path)
+
+    if not FileAccess.file_exists(full_scene_path):
+        printerr("Scene file does not exist at: " + full_scene_path)
+        quit(1)
+
+    var scene = load(full_scene_path)
+    if not scene:
+        printerr("Failed to load scene: " + full_scene_path)
+        quit(1)
+
+    var scene_root = scene.instantiate()
+    if scene_root == null:
+        printerr("Failed to instantiate scene: " + full_scene_path)
+        quit(1)
+
+    var warnings_list: Array = []
+    _collect_warnings_recursive(scene_root, scene_root, warnings_list)
+
+    print("WARNINGS_JSON_START")
+    print(JSON.stringify({
+        "scene_path": full_scene_path,
+        "root": scene_root.name,
+        "warnings": warnings_list,
+        "count": warnings_list.size(),
+    }))
+    print("WARNINGS_JSON_END")
+
+    scene_root.queue_free()
+
+func _collect_warnings_recursive(scene_root: Node, node: Node, results: Array) -> void:
+    var messages: Array = []
+    if node.has_method("_get_configuration_warnings"):
+        var raw: Variant = node.call("_get_configuration_warnings")
+        if raw is PackedStringArray:
+            for w in raw:
+                messages.append(str(w))
+        elif raw is Array:
+            for w in raw:
+                messages.append(str(w))
+
+    if messages.size() > 0:
+        var rel_path: String = "." if node == scene_root else String(scene_root.get_path_to(node))
+        results.append({
+            "path": rel_path,
+            "name": String(node.name),
+            "class": node.get_class(),
+            "messages": messages,
+        })
+
+    for child in node.get_children():
+        _collect_warnings_recursive(scene_root, child, results)
 
 # Modify a node's properties in a scene file
 func modify_node(params):

--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -922,8 +922,11 @@ func _get_uid_inline(res_path: String) -> String:
         return ""
     var head := f.get_buffer(2048).get_string_from_utf8()
     f.close()
+    # Accept quoting variations Godot has used across 4.x: uid="uid://…",
+    # uid='uid://…', and rare unquoted forms. Whitespace around = is also
+    # tolerated in case a future writer reformats the header.
     var rx := RegEx.new()
-    rx.compile('uid="(uid://[a-z0-9]+)"')
+    rx.compile('uid\\s*=\\s*["\']?(uid://[a-z0-9]+)')
     var m := rx.search(head)
     return m.get_string(1) if m else ""
 

--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -910,35 +910,67 @@ func find_files(path, extension):
     return files
 
 # Get UID for a specific file
+# Godot 4.4+ inlines the UID into the header of .tscn / .tres / shader files
+# instead of (or in addition to) a sidecar .uid file. Scan the first 2 KB for
+# a uid="uid://…" attribute before falling back to the sidecar path.
+func _get_uid_inline(res_path: String) -> String:
+    var ext := res_path.get_extension().to_lower()
+    if ext not in ["tscn", "tres", "gdshader", "gdshaderinc"]:
+        return ""
+    var f := FileAccess.open(res_path, FileAccess.READ)
+    if f == null:
+        return ""
+    var head := f.get_buffer(2048).get_string_from_utf8()
+    f.close()
+    var rx := RegEx.new()
+    rx.compile('uid="(uid://[a-z0-9]+)"')
+    var m := rx.search(head)
+    return m.get_string(1) if m else ""
+
 func get_uid(params):
     if not params.has("file_path"):
         printerr("File path is required")
         quit(1)
-    
+
     # Ensure the file path starts with res:// for Godot's resource system
     var file_path = params.file_path
     if not file_path.begins_with("res://"):
         file_path = "res://" + file_path
-    
+
     print("Getting UID for file: " + file_path)
     if debug_mode:
         print("Full file path (with res://): " + file_path)
-    
+
     # Get the absolute path for reference
     var absolute_path = ProjectSettings.globalize_path(file_path)
     if debug_mode:
         print("Absolute file path: " + absolute_path)
-    
+
     # Ensure the file exists
     var file_check = FileAccess.file_exists(file_path)
     if debug_mode:
         print("File exists check: " + str(file_check))
-    
+
     if not file_check:
         printerr("File does not exist at: " + file_path)
         printerr("Absolute file path that doesn't exist: " + absolute_path)
         quit(1)
-    
+
+    # Try inline UID first (Godot 4.4+ headers for scenes/resources/shaders)
+    var inline_uid: String = _get_uid_inline(file_path)
+    if inline_uid != "":
+        var inline_result = {
+            "file": file_path,
+            "absolutePath": absolute_path,
+            "uid": inline_uid,
+            "exists": true,
+            "source": "inline"
+        }
+        if debug_mode:
+            print("Inline UID result: " + JSON.stringify(inline_result))
+        print(JSON.stringify(inline_result))
+        return
+
     # Check if the UID file exists
     var uid_path = file_path + ".uid"
     if debug_mode:

--- a/src/scripts/mcp_interaction_server.gd
+++ b/src/scripts/mcp_interaction_server.gd
@@ -2549,22 +2549,22 @@ func _cmd_ui_theme(params: Dictionary) -> void:
 
 	# Color overrides
 	var colors: Dictionary = overrides.get("colors", {})
-	for name in colors:
-		var c: Dictionary = colors[name]
-		ctrl.add_theme_color_override(name, Color(float(c.get("r", 0)), float(c.get("g", 0)), float(c.get("b", 0)), float(c.get("a", 1))))
-		applied.append("color:" + name)
+	for theme_name in colors:
+		var c: Dictionary = colors[theme_name]
+		ctrl.add_theme_color_override(theme_name, Color(float(c.get("r", 0)), float(c.get("g", 0)), float(c.get("b", 0)), float(c.get("a", 1))))
+		applied.append("color:" + theme_name)
 
 	# Constant overrides
 	var constants: Dictionary = overrides.get("constants", {})
-	for name in constants:
-		ctrl.add_theme_constant_override(name, int(constants[name]))
-		applied.append("constant:" + name)
+	for theme_name in constants:
+		ctrl.add_theme_constant_override(theme_name, int(constants[theme_name]))
+		applied.append("constant:" + theme_name)
 
 	# Font size overrides
 	var font_sizes: Dictionary = overrides.get("font_sizes", {})
-	for name in font_sizes:
-		ctrl.add_theme_font_size_override(name, int(font_sizes[name]))
-		applied.append("font_size:" + name)
+	for theme_name in font_sizes:
+		ctrl.add_theme_font_size_override(theme_name, int(font_sizes[theme_name]))
+		applied.append("font_size:" + theme_name)
 
 	_send_response({"success": true, "node_path": node_path, "applied": applied})
 
@@ -2900,7 +2900,7 @@ func _cmd_input_state(params: Dictionary) -> void:
 			_send_response({"success": true, "action": "warp_mouse", "position": {"x": pos.x, "y": pos.y}})
 		"set_mouse_mode":
 			var mode_str: String = params.get("mouse_mode", "visible")
-			var mode_val: int = Input.MOUSE_MODE_VISIBLE
+			var mode_val: Input.MouseMode = Input.MOUSE_MODE_VISIBLE
 			match mode_str:
 				"hidden": mode_val = Input.MOUSE_MODE_HIDDEN
 				"captured": mode_val = Input.MOUSE_MODE_CAPTURED
@@ -3086,7 +3086,7 @@ func _cmd_process_mode(params: Dictionary) -> void:
 		_send_response({"error": "Node not found: %s" % node_path})
 		return
 	var mode_str: String = params.get("mode", "inherit")
-	var mode_val: int = Node.PROCESS_MODE_INHERIT
+	var mode_val: Node.ProcessMode = Node.PROCESS_MODE_INHERIT
 	match mode_str:
 		"pausable": mode_val = Node.PROCESS_MODE_PAUSABLE
 		"when_paused": mode_val = Node.PROCESS_MODE_WHEN_PAUSED

--- a/src/scripts/mcp_interaction_server.gd
+++ b/src/scripts/mcp_interaction_server.gd
@@ -11,6 +11,10 @@ var _busy: bool = false
 var _busy_since: float = 0.0
 const PORT: int = 9090
 const BUSY_TIMEOUT: float = 30.0
+# Bumped whenever the RPC surface changes so the MCP server can detect stale
+# autoload copies (e.g. a project that registered an older version under a
+# custom res:// path that bypassed injection). Surfaced via get_pid.
+const VERSION: String = "1.4.0"
 var _key_map: Dictionary
 var _held_keys: Dictionary = {}
 
@@ -103,6 +107,17 @@ func _handle_command(json_str: String) -> void:
 	var params: Dictionary = data.get("params", {})
 
 	match command:
+		# Identity handshake — lets MCP pin the real spawned-game PID without
+		# any Windows-side process enumeration (which can't distinguish an
+		# editor and a game that both have the project path in their cmdline).
+		"get_pid":
+			_send_response({"pid": OS.get_process_id(), "version": VERSION})
+		"quit":
+			# Send ack first so the client sees the response before the socket
+			# tears down, then defer the actual quit to the next idle frame so
+			# the outbound write flushes.
+			_send_response({"success": true, "version": VERSION})
+			get_tree().call_deferred("quit")
 		# Async commands (use await)
 		"screenshot":
 			await _cmd_screenshot()

--- a/src/scripts/mcp_interaction_server.gd
+++ b/src/scripts/mcp_interaction_server.gd
@@ -2984,15 +2984,13 @@ func _cmd_script(params: Dictionary) -> void:
 			if s is GDScript:
 				language = "gdscript"
 				source_text = s.source_code
-			# Use a string compare against "CSharpScript" rather than `is
-			# CSharpScript`: non-mono Godot builds don't ship the CSharpScript
-			# type at all, so a typed reference would fail to parse this
-			# autoload. get_class() works on every build.
-			elif s.get_class() == "CSharpScript":
-				language = "csharp"
-				if s.resource_path != "" and FileAccess.file_exists(s.resource_path):
-					source_text = FileAccess.get_file_as_string(s.resource_path)
 			else:
+				# Use a string compare against "CSharpScript" rather than
+				# `is CSharpScript`: non-mono Godot builds don't ship the
+				# CSharpScript type at all, so a typed reference would fail
+				# to parse this autoload. get_class() works on every build.
+				if s.get_class() == "CSharpScript":
+					language = "csharp"
 				if s.resource_path != "" and FileAccess.file_exists(s.resource_path):
 					source_text = FileAccess.get_file_as_string(s.resource_path)
 			_send_response({"success": true, "has_script": true, "source": source_text, "path": s.resource_path, "language": language})

--- a/src/scripts/mcp_interaction_server.gd
+++ b/src/scripts/mcp_interaction_server.gd
@@ -2984,6 +2984,10 @@ func _cmd_script(params: Dictionary) -> void:
 			if s is GDScript:
 				language = "gdscript"
 				source_text = s.source_code
+			# Use a string compare against "CSharpScript" rather than `is
+			# CSharpScript`: non-mono Godot builds don't ship the CSharpScript
+			# type at all, so a typed reference would fail to parse this
+			# autoload. get_class() works on every build.
 			elif s.get_class() == "CSharpScript":
 				language = "csharp"
 				if s.resource_path != "" and FileAccess.file_exists(s.resource_path):

--- a/src/scripts/mcp_interaction_server.gd
+++ b/src/scripts/mcp_interaction_server.gd
@@ -2979,12 +2979,40 @@ func _cmd_script(params: Dictionary) -> void:
 			if s == null:
 				_send_response({"success": true, "has_script": false})
 				return
-			_send_response({"success": true, "has_script": true, "source": s.source_code if s is GDScript else "", "path": s.resource_path})
+			var language: String = "unknown"
+			var source_text: String = ""
+			if s is GDScript:
+				language = "gdscript"
+				source_text = s.source_code
+			elif s.get_class() == "CSharpScript":
+				language = "csharp"
+				if s.resource_path != "" and FileAccess.file_exists(s.resource_path):
+					source_text = FileAccess.get_file_as_string(s.resource_path)
+			else:
+				if s.resource_path != "" and FileAccess.file_exists(s.resource_path):
+					source_text = FileAccess.get_file_as_string(s.resource_path)
+			_send_response({"success": true, "has_script": true, "source": source_text, "path": s.resource_path, "language": language})
 		"attach":
+			var script_path: String = params.get("script_path", "")
+			if not script_path.is_empty():
+				# Load a precompiled script from disk (works for .gd and .cs).
+				if not script_path.begins_with("res://"):
+					script_path = "res://" + script_path
+				if not FileAccess.file_exists(script_path):
+					_send_response({"error": "Script file does not exist: %s" % script_path})
+					return
+				var loaded: Script = load(script_path) as Script
+				if loaded == null:
+					_send_response({"error": "Failed to load script as Script resource: %s" % script_path})
+					return
+				node.set_script(loaded)
+				_send_response({"success": true, "action": "attach", "node_path": node_path, "script_path": script_path})
+				return
 			var source: String = params.get("source", "")
 			if source.is_empty():
-				_send_response({"error": "source is required for attach"})
+				_send_response({"error": "Either script_path or source is required for attach"})
 				return
+			# Inline source compilation only works for GDScript at runtime.
 			var s: GDScript = GDScript.new()
 			s.source_code = source
 			var err: int = s.reload()

--- a/src/tool-filter.ts
+++ b/src/tool-filter.ts
@@ -150,12 +150,16 @@ export class ToolFilter {
   }
 }
 
+// Empty / whitespace-only env vars are treated the same as unset so a stray
+// `export GODOT_MCP_DISABLED_TOOLS=` in a shell rc can't silently wipe a
+// JSON-configured denylist.
 function parseList(value: string | undefined): string[] | undefined {
   if (value === undefined) return undefined;
-  return value
+  const items = value
     .split(',')
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
+  return items.length === 0 ? undefined : items;
 }
 
 function warnUnknown(field: string, requested: Set<string>, available: Set<string>): void {

--- a/src/tool-filter.ts
+++ b/src/tool-filter.ts
@@ -1,0 +1,166 @@
+/**
+ * Tool filtering for the Godot MCP server.
+ *
+ * Lets operators restrict which tools are exposed to the MCP client via
+ * environment variables or a JSON config file. Useful for stripping
+ * GDScript-only tools from pure-C# projects, or narrowing the tool surface
+ * for agents that only need a subset.
+ *
+ * Sources, in merge order (later overrides earlier, per-field):
+ *   1. JSON file pointed at by GODOT_MCP_CONFIG
+ *   2. Environment variables (see loadFromEnv)
+ *
+ * Filter fields:
+ *   - enabledTools: if set, only tools whose name is in this list pass
+ *   - disabledTools: tools whose name is in this list are excluded
+ *   - enabledTags:   if set, a tool must carry at least one matching tag
+ *   - disabledTags:  a tool carrying any matching tag is excluded
+ *
+ * Precedence: enable gates are applied before disable gates, so a tool
+ * that is both enabled and disabled ends up excluded.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+
+export interface ToolDef {
+  name: string;
+  description: string;
+  inputSchema: unknown;
+  tags?: string[];
+}
+
+export interface ToolFilterConfig {
+  enabledTools?: string[];
+  disabledTools?: string[];
+  enabledTags?: string[];
+  disabledTags?: string[];
+}
+
+export class ToolFilter {
+  private readonly enabledTools?: Set<string>;
+  private readonly disabledTools: Set<string>;
+  private readonly enabledTags?: Set<string>;
+  private readonly disabledTags: Set<string>;
+  private enabledNames: Set<string> = new Set();
+  private applied = false;
+
+  constructor(config: ToolFilterConfig = {}) {
+    this.enabledTools = config.enabledTools ? new Set(config.enabledTools) : undefined;
+    this.disabledTools = new Set(config.disabledTools ?? []);
+    this.enabledTags = config.enabledTags ? new Set(config.enabledTags) : undefined;
+    this.disabledTags = new Set(config.disabledTags ?? []);
+  }
+
+  /**
+   * Build a ToolFilter from GODOT_MCP_CONFIG (optional JSON file) plus
+   * env-var overrides. Throws if the config file is missing or invalid JSON.
+   */
+  static load(env: NodeJS.ProcessEnv = process.env): ToolFilter {
+    const config: ToolFilterConfig = {};
+    const configPath = env.GODOT_MCP_CONFIG;
+    if (configPath) {
+      if (!existsSync(configPath)) {
+        throw new Error(`GODOT_MCP_CONFIG file not found: ${configPath}`);
+      }
+      let raw: string;
+      try {
+        raw = readFileSync(configPath, 'utf8');
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        throw new Error(`Failed to read GODOT_MCP_CONFIG (${configPath}): ${msg}`);
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        throw new Error(`GODOT_MCP_CONFIG is not valid JSON (${configPath}): ${msg}`);
+      }
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error(`GODOT_MCP_CONFIG must be a JSON object (${configPath})`);
+      }
+      const obj = parsed as Record<string, unknown>;
+      const assignList = (key: keyof ToolFilterConfig) => {
+        const v = obj[key];
+        if (v === undefined) return;
+        if (!Array.isArray(v) || !v.every((x) => typeof x === 'string')) {
+          throw new Error(`GODOT_MCP_CONFIG: field '${key}' must be an array of strings`);
+        }
+        config[key] = v as string[];
+      };
+      assignList('enabledTools');
+      assignList('disabledTools');
+      assignList('enabledTags');
+      assignList('disabledTags');
+    }
+
+    const envEnabledTools = parseList(env.GODOT_MCP_ENABLED_TOOLS);
+    const envDisabledTools = parseList(env.GODOT_MCP_DISABLED_TOOLS);
+    const envEnabledTags = parseList(env.GODOT_MCP_ENABLED_TAGS);
+    const envDisabledTags = parseList(env.GODOT_MCP_DISABLED_TAGS);
+    if (envEnabledTools !== undefined) config.enabledTools = envEnabledTools;
+    if (envDisabledTools !== undefined) config.disabledTools = envDisabledTools;
+    if (envEnabledTags !== undefined) config.enabledTags = envEnabledTags;
+    if (envDisabledTags !== undefined) config.disabledTags = envDisabledTags;
+
+    return new ToolFilter(config);
+  }
+
+  /**
+   * Apply the filter to a list of tool definitions. Populates internal state
+   * used by isEnabled(). Emits warnings (stderr) for unknown tool names and
+   * tags so misconfigured filters don't silently pass everything through.
+   */
+  filter<T extends ToolDef>(tools: T[]): T[] {
+    const allNames = new Set(tools.map((t) => t.name));
+    const allTags = new Set<string>();
+    for (const t of tools) {
+      for (const tag of t.tags ?? []) allTags.add(tag);
+    }
+
+    if (this.enabledTools) {
+      warnUnknown('enabledTools', this.enabledTools, allNames);
+    }
+    warnUnknown('disabledTools', this.disabledTools, allNames);
+    if (this.enabledTags) {
+      warnUnknown('enabledTags', this.enabledTags, allTags);
+    }
+    warnUnknown('disabledTags', this.disabledTags, allTags);
+
+    const filtered = tools.filter((t) => this.accept(t));
+    this.enabledNames = new Set(filtered.map((t) => t.name));
+    this.applied = true;
+    return filtered;
+  }
+
+  isEnabled(name: string): boolean {
+    if (!this.applied) {
+      throw new Error('ToolFilter.isEnabled() called before filter()');
+    }
+    return this.enabledNames.has(name);
+  }
+
+  private accept(tool: ToolDef): boolean {
+    if (this.enabledTools && !this.enabledTools.has(tool.name)) return false;
+    if (this.disabledTools.has(tool.name)) return false;
+    const tags = tool.tags ?? [];
+    if (this.enabledTags && !tags.some((t) => this.enabledTags!.has(t))) return false;
+    if (tags.some((t) => this.disabledTags.has(t))) return false;
+    return true;
+  }
+}
+
+function parseList(value: string | undefined): string[] | undefined {
+  if (value === undefined) return undefined;
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function warnUnknown(field: string, requested: Set<string>, available: Set<string>): void {
+  const unknown = [...requested].filter((v) => !available.has(v));
+  if (unknown.length > 0) {
+    console.error(`[WARN] ToolFilter: unknown ${field}: ${unknown.join(', ')}`);
+  }
+}

--- a/src/tool-filter.ts
+++ b/src/tool-filter.ts
@@ -20,7 +20,7 @@
  * that is both enabled and disabled ends up excluded.
  */
 
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'node:fs';
 
 export interface ToolDef {
   name: string;
@@ -56,43 +56,9 @@ export class ToolFilter {
    * env-var overrides. Throws if the config file is missing or invalid JSON.
    */
   static load(env: NodeJS.ProcessEnv = process.env): ToolFilter {
-    const config: ToolFilterConfig = {};
-    const configPath = env.GODOT_MCP_CONFIG;
-    if (configPath) {
-      if (!existsSync(configPath)) {
-        throw new Error(`GODOT_MCP_CONFIG file not found: ${configPath}`);
-      }
-      let raw: string;
-      try {
-        raw = readFileSync(configPath, 'utf8');
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        throw new Error(`Failed to read GODOT_MCP_CONFIG (${configPath}): ${msg}`);
-      }
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(raw);
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        throw new Error(`GODOT_MCP_CONFIG is not valid JSON (${configPath}): ${msg}`);
-      }
-      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-        throw new Error(`GODOT_MCP_CONFIG must be a JSON object (${configPath})`);
-      }
-      const obj = parsed as Record<string, unknown>;
-      const assignList = (key: keyof ToolFilterConfig) => {
-        const v = obj[key];
-        if (v === undefined) return;
-        if (!Array.isArray(v) || !v.every((x) => typeof x === 'string')) {
-          throw new Error(`GODOT_MCP_CONFIG: field '${key}' must be an array of strings`);
-        }
-        config[key] = v as string[];
-      };
-      assignList('enabledTools');
-      assignList('disabledTools');
-      assignList('enabledTags');
-      assignList('disabledTags');
-    }
+    const config: ToolFilterConfig = env.GODOT_MCP_CONFIG
+      ? loadConfigFile(env.GODOT_MCP_CONFIG)
+      : {};
 
     const envEnabledTools = parseList(env.GODOT_MCP_ENABLED_TOOLS);
     const envDisabledTools = parseList(env.GODOT_MCP_DISABLED_TOOLS);
@@ -148,6 +114,65 @@ export class ToolFilter {
     if (tags.some((t) => this.disabledTags.has(t))) return false;
     return true;
   }
+}
+
+const CONFIG_FIELDS: Array<keyof ToolFilterConfig> = [
+  'enabledTools',
+  'disabledTools',
+  'enabledTags',
+  'disabledTags',
+];
+
+function loadConfigFile(configPath: string): ToolFilterConfig {
+  if (!existsSync(configPath)) {
+    throw new Error(`GODOT_MCP_CONFIG file not found: ${configPath}`);
+  }
+  const raw = readConfigFile(configPath);
+  const parsed = parseConfigFile(configPath, raw);
+  const config: ToolFilterConfig = {};
+  for (const key of CONFIG_FIELDS) {
+    const list = coerceStringArray(parsed[key], key);
+    if (list) config[key] = list;
+  }
+  return config;
+}
+
+function readConfigFile(configPath: string): string {
+  try {
+    return readFileSync(configPath, 'utf8');
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`Failed to read GODOT_MCP_CONFIG (${configPath}): ${msg}`);
+  }
+}
+
+function parseConfigFile(configPath: string, raw: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`GODOT_MCP_CONFIG is not valid JSON (${configPath}): ${msg}`);
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`GODOT_MCP_CONFIG must be a JSON object (${configPath})`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((x) => typeof x === 'string');
+}
+
+function coerceStringArray(
+  value: unknown,
+  field: keyof ToolFilterConfig
+): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!isStringArray(value)) {
+    throw new Error(`GODOT_MCP_CONFIG: field '${field}' must be an array of strings`);
+  }
+  return value;
 }
 
 // Empty / whitespace-only env vars are treated the same as unset so a stray

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -240,8 +240,24 @@ function getAllowedProjectRoots(): string[] {
 
 function normalizeScopedPath(path: string): string {
   if (!path) return '';
-  const wslPath = path.match(/^[A-Za-z]:[\\/]/) ? toWslProjectPath(path) : path;
-  return normalize(wslPath).replace(/\\/g, '/').replace(/\/+$/, '');
+  const wslPath = isWindowsAbsoluteDrivePath(path) ? toWslProjectPath(path) : path;
+  return stripTrailingForwardSlashes(normalize(wslPath).replaceAll('\\', '/'));
+}
+
+function isWindowsAbsoluteDrivePath(path: string): boolean {
+  if (path.length < 3 || path.charCodeAt(1) !== 58) return false;
+  const drive = path.charCodeAt(0);
+  const separator = path.charCodeAt(2);
+  const isDriveLetter = (drive >= 65 && drive <= 90) || (drive >= 97 && drive <= 122);
+  return isDriveLetter && (separator === 47 || separator === 92);
+}
+
+function stripTrailingForwardSlashes(path: string): string {
+  let end = path.length;
+  while (end > 0 && path.charCodeAt(end - 1) === 47) {
+    end--;
+  }
+  return end === path.length ? path : path.slice(0, end);
 }
 
 export function createErrorResponse(message: string): any {
@@ -330,9 +346,12 @@ export function addGodotIniSectionLine(content: string, section: string, line: s
       }
     }
 
-    let insertIndex = sectionIndex + 1;
-    while (insertIndex < lines.length && lines[insertIndex].trim() === '') {
-      lines.splice(insertIndex, 1);
+    // Append after the last existing entry, skipping back over trailing blank
+    // lines. This keeps Godot's blank line after the header intact so removal
+    // can splice just our line back out and round-trip byte-for-byte.
+    let insertIndex = sectionEnd;
+    while (insertIndex > sectionIndex + 1 && lines[insertIndex - 1].trim() === '') {
+      insertIndex--;
     }
     lines.splice(insertIndex, 0, line);
     return joinGodotIniLines(lines, newline, parsed.trailingNewline);
@@ -370,30 +389,29 @@ export function removeGodotIniSectionLine(content: string, section: string, key:
   }
 
   sectionEnd = findGodotIniSectionEnd(lines, sectionIndex + 1);
-  while (sectionIndex + 1 < sectionEnd && lines[sectionIndex + 1].trim() === '') {
-    lines.splice(sectionIndex + 1, 1);
-    sectionEnd = findGodotIniSectionEnd(lines, sectionIndex + 1);
-  }
-  while (sectionEnd - 1 > sectionIndex && lines[sectionEnd - 1].trim() === '') {
-    lines.splice(sectionEnd - 1, 1);
-    sectionEnd = findGodotIniSectionEnd(lines, sectionIndex + 1);
-  }
-
   const hasRemainingContent = lines
     .slice(sectionIndex + 1, sectionEnd)
     .some(sectionLine => sectionLine.trim() !== '');
-  if (!hasRemainingContent) {
-    lines.splice(sectionIndex, sectionEnd - sectionIndex);
-    if (sectionIndex === lines.length && lines.length > 0 && lines[lines.length - 1].trim() === '') {
-      lines.pop();
-    } else if (
-      sectionIndex > 0 &&
-      sectionIndex < lines.length &&
-      lines[sectionIndex - 1].trim() === '' &&
-      lines[sectionIndex].trim() === ''
-    ) {
-      lines.splice(sectionIndex, 1);
-    }
+
+  // Other entries remain: drop only the matched line(s) and leave the
+  // surrounding whitespace untouched, so Godot's blank line after the header
+  // and before the next section survive and the file round-trips unchanged.
+  if (hasRemainingContent) {
+    return joinGodotIniLines(lines, newline, parsed.trailingNewline && lines.length > 0);
+  }
+
+  // The section is now empty, meaning we injected it wholesale: remove the
+  // header and the separator blank line we added in front of it.
+  lines.splice(sectionIndex, sectionEnd - sectionIndex);
+  if (sectionIndex === lines.length && lines.length > 0 && lines[lines.length - 1].trim() === '') {
+    lines.pop();
+  } else if (
+    sectionIndex > 0 &&
+    sectionIndex < lines.length &&
+    lines[sectionIndex - 1].trim() === '' &&
+    lines[sectionIndex].trim() === ''
+  ) {
+    lines.splice(sectionIndex, 1);
   }
 
   return joinGodotIniLines(lines, newline, parsed.trailingNewline && lines.length > 0);
@@ -442,8 +460,11 @@ function godotIniLineMatchesKey(line: string, key: string): boolean {
   if (!trimmed || trimmed.startsWith(';')) {
     return false;
   }
-  const match = /^([^=]+)\s*=/.exec(trimmed);
-  return match?.[1].trim() === key;
+  const separatorIndex = trimmed.indexOf('=');
+  if (separatorIndex <= 0) {
+    return false;
+  }
+  return trimmed.slice(0, separatorIndex).trim() === key;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@
  * Pure functions extracted for testability.
  */
 
-import { join } from 'node:path';
+import { isAbsolute, join, normalize } from 'node:path';
 
 export interface OperationParams {
   [key: string]: any;
@@ -208,7 +208,40 @@ export function validatePath(path: string): boolean {
   if (!path || path.includes('..')) {
     return false;
   }
+
   return true;
+}
+
+export function validateProjectPath(path: string): boolean {
+  if (!validatePath(path)) {
+    return false;
+  }
+
+  const scopedPath = normalizeScopedPath(path);
+  const allowedRoots = getAllowedProjectRoots();
+  if (!isAbsolute(scopedPath)) {
+    return allowedRoots.length === 0;
+  }
+
+  if (allowedRoots.length === 0) {
+    return true;
+  }
+
+  return allowedRoots.some(root => scopedPath === root || scopedPath.startsWith(`${root}/`));
+}
+
+function getAllowedProjectRoots(): string[] {
+  return (process.env.GODOT_MCP_PROJECT_ROOTS ?? '')
+    .split(',')
+    .map(root => root.trim())
+    .filter(Boolean)
+    .map(normalizeScopedPath);
+}
+
+function normalizeScopedPath(path: string): string {
+  if (!path) return '';
+  const wslPath = path.match(/^[A-Za-z]:[\\/]/) ? toWslProjectPath(path) : path;
+  return normalize(wslPath).replace(/\\/g, '/').replace(/\/+$/, '');
 }
 
 export function createErrorResponse(message: string): any {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,8 @@
  * Pure functions extracted for testability.
  */
 
+import { join } from 'path';
+
 export interface OperationParams {
   [key: string]: any;
 }
@@ -231,4 +233,152 @@ export function isGodot44OrLater(version: string): boolean {
     return major > 4 || (major === 4 && minor >= 4);
   }
   return false;
+}
+
+/**
+ * Convert a Windows-style path (e.g. "C:/foo/bar" or "C:\\foo\\bar") into the
+ * WSL mount form ("/mnt/c/foo/bar"). Paths that aren't Windows-native pass
+ * through unchanged. Only active on linux — on Windows and macOS the native
+ * fs layer resolves paths directly.
+ */
+export function toWslProjectPath(p: string): string {
+  if (!p || process.platform !== 'linux') return p;
+  const m = p.match(/^([A-Za-z]):[\\/](.*)$/);
+  return m ? `/mnt/${m[1].toLowerCase()}/${m[2].replace(/\\/g, '/')}` : p;
+}
+
+/**
+ * Inverse of toWslProjectPath. Converts "/mnt/c/foo/bar" back to "C:/foo/bar"
+ * so a Windows-native Godot executable (Godot.exe invoked via WSL interop)
+ * receives a path it can open. Passthrough for non-mount paths. Linux-only.
+ */
+export function toNativeProjectPath(p: string): string {
+  if (!p || process.platform !== 'linux') return p;
+  const m = p.match(/^\/mnt\/([a-z])\/(.*)$/i);
+  return m ? `${m[1].toUpperCase()}:/${m[2]}` : p;
+}
+
+/**
+ * True when the configured Godot executable is a Windows binary invoked via
+ * WSL interop. Used to decide whether child processes need a Windows-style
+ * project path rather than the /mnt/... form.
+ */
+export function isWindowsGodotExe(godotPath: string | null | undefined): boolean {
+  return !!godotPath && godotPath.toLowerCase().endsWith('.exe');
+}
+
+/**
+ * Join a project directory with "project.godot", translating Windows-style
+ * paths to the WSL mount form first so fs.existsSync can resolve them when
+ * running on linux.
+ */
+export function projectGodotFile(projectPath: string): string {
+  return join(toWslProjectPath(projectPath), 'project.godot');
+}
+
+/**
+ * Parse a Godot-style INI file (project.godot, export_presets.cfg, …) into a
+ * `{ section: { key: value } }` map. Unlike a naive line-by-line parser this
+ * concatenates continuation lines for values whose RHS starts with `{`, `[`,
+ * or a quoted string and whose closing delimiter lives on a later line —
+ * required for Godot's input map, where each action is serialized as a
+ * multi-line dictionary:
+ *
+ *   PaintGrass={
+ *   "deadzone": 0.5,
+ *   "events": [Object(InputEventKey,"keycode":71,…)]
+ *   }
+ *
+ * Depth tracking ignores braces/brackets that appear inside double-quoted
+ * string literals so embedded `}` characters don't close the block early.
+ * Returns raw string values — callers can JSON.parse them if needed.
+ */
+export function parseGodotIni(content: string): Record<string, Record<string, string>> {
+  const sections: Record<string, Record<string, string>> = {};
+  const lines = content.split('\n');
+  let currentSection = '';
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    if (trimmed === '' || trimmed.startsWith(';')) {
+      i++;
+      continue;
+    }
+
+    // Section header
+    const sectionMatch = trimmed.match(/^\[(.+)\]$/);
+    if (sectionMatch) {
+      currentSection = sectionMatch[1];
+      if (!sections[currentSection]) sections[currentSection] = {};
+      i++;
+      continue;
+    }
+
+    // Key=value pair, possibly spanning multiple lines.
+    const kvMatch = trimmed.match(/^([^=]+)=(.*)$/);
+    if (kvMatch && currentSection) {
+      const key = kvMatch[1].trim();
+      let value = kvMatch[2];
+      let depth = countIniDepth(value);
+      i++;
+      while (depth > 0 && i < lines.length) {
+        value += '\n' + lines[i];
+        depth += countIniDepth(lines[i]);
+        i++;
+      }
+      sections[currentSection][key] = value.trim();
+      continue;
+    }
+    i++;
+  }
+
+  return sections;
+}
+
+function countIniDepth(text: string): number {
+  let depth = 0;
+  let inString = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '\\' && inString) {
+      i++;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === '{' || ch === '[') depth++;
+    else if (ch === '}' || ch === ']') depth--;
+  }
+  return depth;
+}
+
+/**
+ * Translate an arbitrary linux path into a form a Windows Godot.exe (invoked
+ * via WSL interop) can open:
+ *   - `/mnt/<c>/...`  → `C:/...`
+ *   - `/home/...`, `/usr/...`, etc. → `\\wsl.localhost\<distro>\<rest>`
+ *   - Windows-native paths (`C:/...`) pass through
+ *
+ * Only active when godotPath is a .exe on linux; otherwise returns the input
+ * unchanged. Distro name comes from $WSL_DISTRO_NAME when available,
+ * defaulting to "Ubuntu".
+ */
+export function toWindowsAccessiblePath(
+  p: string,
+  godotPath: string | null | undefined
+): string {
+  if (!p || !isWindowsGodotExe(godotPath) || process.platform !== 'linux') return p;
+  // Already Windows-native
+  if (/^[A-Za-z]:[\\/]/.test(p)) return p;
+  // /mnt/<letter>/... → <Letter>:/...
+  const mnt = p.match(/^\/mnt\/([a-z])\/(.*)$/i);
+  if (mnt) return `${mnt[1].toUpperCase()}:/${mnt[2]}`;
+  // Linux-native path → WSL UNC (backslash-separated for Windows).
+  const distro = process.env.WSL_DISTRO_NAME || 'Ubuntu';
+  return `\\\\wsl.localhost\\${distro}\\${p.replace(/^\//, '').replace(/\//g, '\\')}`;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@
  * Pure functions extracted for testability.
  */
 
-import { join } from 'path';
+import { join } from 'node:path';
 
 export interface OperationParams {
   [key: string]: any;
@@ -243,8 +243,8 @@ export function isGodot44OrLater(version: string): boolean {
  */
 export function toWslProjectPath(p: string): string {
   if (!p || process.platform !== 'linux') return p;
-  const m = p.match(/^([A-Za-z]):[\\/](.*)$/);
-  return m ? `/mnt/${m[1].toLowerCase()}/${m[2].replace(/\\/g, '/')}` : p;
+  const m = /^([A-Za-z]):[\\/](.*)$/.exec(p);
+  return m ? `/mnt/${m[1].toLowerCase()}/${m[2].replaceAll('\\', '/')}` : p;
 }
 
 /**
@@ -254,7 +254,7 @@ export function toWslProjectPath(p: string): string {
  */
 export function toNativeProjectPath(p: string): string {
   if (!p || process.platform !== 'linux') return p;
-  const m = p.match(/^\/mnt\/([a-z])\/(.*)$/i);
+  const m = /^\/mnt\/([a-z])\/(.*)$/i.exec(p);
   return m ? `${m[1].toUpperCase()}:/${m[2]}` : p;
 }
 
@@ -315,7 +315,7 @@ export function parseGodotIni(content: string): Record<string, Record<string, st
     }
 
     // Section header
-    const sectionMatch = trimmed.match(/^\[(.+)\]$/);
+    const sectionMatch = /^\[(.+)\]$/.exec(trimmed);
     if (sectionMatch) {
       currentSection = sectionMatch[1];
       if (!sections[currentSection]) sections[currentSection] = {};
@@ -326,7 +326,7 @@ export function parseGodotIni(content: string): Record<string, Record<string, st
     // Key=value pair, possibly spanning multiple lines. String state carries
     // across lines so a literal that opens on one line and closes on a later
     // line doesn't confuse depth tracking.
-    const kvMatch = trimmed.match(/^([^=]+)=(.*)$/);
+    const kvMatch = /^([^=]+)=(.*)$/.exec(trimmed);
     if (kvMatch && currentSection) {
       const key = kvMatch[1].trim();
       const walker = { depth: 0, inString: false };
@@ -387,12 +387,12 @@ export function toWindowsAccessiblePath(
   if (!p || !isWindowsGodotExe(godotPath) || process.platform !== 'linux') return p;
   // Already a Windows UNC path (\\server\share\…). Leave alone so we don't
   // stack a second UNC prefix.
-  if (/^\\\\/.test(p) || /^\/\//.test(p)) return p;
+  if (p.startsWith('\\\\') || p.startsWith('//')) return p;
   // Windows drive form — accept "C:", "C:/…", "C:\…", and drive-relative
   // "C:foo". Anything with a drive letter is already native; pass through.
   if (/^[A-Za-z]:/.test(p)) return p;
   // /mnt/<letter>/... → <Letter>:/...
-  const mnt = p.match(/^\/mnt\/([a-z])(?:\/(.*))?$/i);
+  const mnt = /^\/mnt\/([a-z])(?:\/(.*))?$/i.exec(p);
   if (mnt) return `${mnt[1].toUpperCase()}:/${mnt[2] ?? ''}`;
   // Only rewrite absolute linux paths. Relative paths (no leading slash) are
   // left alone — callers that build an absolute path for Godot should do so
@@ -400,5 +400,5 @@ export function toWindowsAccessiblePath(
   if (!p.startsWith('/')) return p;
   // Linux-native absolute path → WSL UNC (backslash-separated for Windows).
   const distro = process.env.WSL_DISTRO_NAME || 'Ubuntu';
-  return `\\\\wsl.localhost\\${distro}\\${p.replace(/^\//, '').replace(/\//g, '\\')}`;
+  return `\\\\wsl.localhost\\${distro}\\${p.slice(1).replaceAll('/', '\\')}`;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -268,12 +268,19 @@ export function isWindowsGodotExe(godotPath: string | null | undefined): boolean
 }
 
 /**
- * Join a project directory with "project.godot", translating Windows-style
- * paths to the WSL mount form first so fs.existsSync can resolve them when
- * running on linux.
+ * Join a project directory with a relative path, translating Windows-style
+ * inputs to the WSL mount form first so Node's fs layer can resolve them on
+ * linux. Use for every filesystem access that combines a user-supplied
+ * project path with a known relative path — project.godot, Dockerfile, a
+ * script under the project, etc.
  */
+export function projectFilePath(projectPath: string, ...parts: string[]): string {
+  return join(toWslProjectPath(projectPath), ...parts);
+}
+
+/** Backwards-compat alias pinned to project.godot. */
 export function projectGodotFile(projectPath: string): string {
-  return join(toWslProjectPath(projectPath), 'project.godot');
+  return projectFilePath(projectPath, 'project.godot');
 }
 
 /**
@@ -316,16 +323,19 @@ export function parseGodotIni(content: string): Record<string, Record<string, st
       continue;
     }
 
-    // Key=value pair, possibly spanning multiple lines.
+    // Key=value pair, possibly spanning multiple lines. String state carries
+    // across lines so a literal that opens on one line and closes on a later
+    // line doesn't confuse depth tracking.
     const kvMatch = trimmed.match(/^([^=]+)=(.*)$/);
     if (kvMatch && currentSection) {
       const key = kvMatch[1].trim();
+      const walker = { depth: 0, inString: false };
       let value = kvMatch[2];
-      let depth = countIniDepth(value);
+      stepIniDepth(value, walker);
       i++;
-      while (depth > 0 && i < lines.length) {
+      while (walker.depth > 0 && i < lines.length) {
         value += '\n' + lines[i];
-        depth += countIniDepth(lines[i]);
+        stepIniDepth(lines[i], walker);
         i++;
       }
       sections[currentSection][key] = value.trim();
@@ -337,24 +347,26 @@ export function parseGodotIni(content: string): Record<string, Record<string, st
   return sections;
 }
 
-function countIniDepth(text: string): number {
-  let depth = 0;
-  let inString = false;
+interface IniDepthWalker {
+  depth: number;
+  inString: boolean;
+}
+
+function stepIniDepth(text: string, w: IniDepthWalker): void {
   for (let i = 0; i < text.length; i++) {
     const ch = text[i];
-    if (ch === '\\' && inString) {
+    if (ch === '\\' && w.inString && i + 1 < text.length) {
       i++;
       continue;
     }
     if (ch === '"') {
-      inString = !inString;
+      w.inString = !w.inString;
       continue;
     }
-    if (inString) continue;
-    if (ch === '{' || ch === '[') depth++;
-    else if (ch === '}' || ch === ']') depth--;
+    if (w.inString) continue;
+    if (ch === '{' || ch === '[') w.depth++;
+    else if (ch === '}' || ch === ']') w.depth--;
   }
-  return depth;
 }
 
 /**
@@ -373,12 +385,20 @@ export function toWindowsAccessiblePath(
   godotPath: string | null | undefined
 ): string {
   if (!p || !isWindowsGodotExe(godotPath) || process.platform !== 'linux') return p;
-  // Already Windows-native
-  if (/^[A-Za-z]:[\\/]/.test(p)) return p;
+  // Already a Windows UNC path (\\server\share\…). Leave alone so we don't
+  // stack a second UNC prefix.
+  if (/^\\\\/.test(p) || /^\/\//.test(p)) return p;
+  // Windows drive form — accept "C:", "C:/…", "C:\…", and drive-relative
+  // "C:foo". Anything with a drive letter is already native; pass through.
+  if (/^[A-Za-z]:/.test(p)) return p;
   // /mnt/<letter>/... → <Letter>:/...
-  const mnt = p.match(/^\/mnt\/([a-z])\/(.*)$/i);
-  if (mnt) return `${mnt[1].toUpperCase()}:/${mnt[2]}`;
-  // Linux-native path → WSL UNC (backslash-separated for Windows).
+  const mnt = p.match(/^\/mnt\/([a-z])(?:\/(.*))?$/i);
+  if (mnt) return `${mnt[1].toUpperCase()}:/${mnt[2] ?? ''}`;
+  // Only rewrite absolute linux paths. Relative paths (no leading slash) are
+  // left alone — callers that build an absolute path for Godot should do so
+  // before calling us.
+  if (!p.startsWith('/')) return p;
+  // Linux-native absolute path → WSL UNC (backslash-separated for Windows).
   const distro = process.env.WSL_DISTRO_NAME || 'Ubuntu';
   return `\\\\wsl.localhost\\${distro}\\${p.replace(/^\//, '').replace(/\//g, '\\')}`;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -283,6 +283,136 @@ export function projectGodotFile(projectPath: string): string {
   return projectFilePath(projectPath, 'project.godot');
 }
 
+export function addGodotIniSectionLine(content: string, section: string, line: string, key: string): string {
+  const newline = detectNewline(content);
+  const parsed = splitGodotIniLines(content);
+  const lines = parsed.lines;
+  const sectionIndex = findGodotIniSection(lines, section);
+
+  if (sectionIndex !== -1) {
+    const sectionEnd = findGodotIniSectionEnd(lines, sectionIndex + 1);
+    for (let i = sectionIndex + 1; i < sectionEnd; i++) {
+      if (godotIniLineMatchesKey(lines[i], key)) {
+        return content;
+      }
+    }
+
+    let insertIndex = sectionIndex + 1;
+    while (insertIndex < lines.length && lines[insertIndex].trim() === '') {
+      lines.splice(insertIndex, 1);
+    }
+    lines.splice(insertIndex, 0, line);
+    return joinGodotIniLines(lines, newline, parsed.trailingNewline);
+  }
+
+  while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+    lines.pop();
+  }
+  if (lines.length > 0) {
+    lines.push('');
+  }
+  lines.push(`[${section}]`, line);
+  return joinGodotIniLines(lines, newline, true);
+}
+
+export function removeGodotIniSectionLine(content: string, section: string, key: string): string {
+  const newline = detectNewline(content);
+  const parsed = splitGodotIniLines(content);
+  const lines = parsed.lines;
+  const sectionIndex = findGodotIniSection(lines, section);
+  if (sectionIndex === -1) {
+    return content;
+  }
+
+  let changed = false;
+  let sectionEnd = findGodotIniSectionEnd(lines, sectionIndex + 1);
+  for (let i = sectionEnd - 1; i > sectionIndex; i--) {
+    if (godotIniLineMatchesKey(lines[i], key)) {
+      lines.splice(i, 1);
+      changed = true;
+    }
+  }
+  if (!changed) {
+    return content;
+  }
+
+  sectionEnd = findGodotIniSectionEnd(lines, sectionIndex + 1);
+  while (sectionIndex + 1 < sectionEnd && lines[sectionIndex + 1].trim() === '') {
+    lines.splice(sectionIndex + 1, 1);
+    sectionEnd = findGodotIniSectionEnd(lines, sectionIndex + 1);
+  }
+  while (sectionEnd - 1 > sectionIndex && lines[sectionEnd - 1].trim() === '') {
+    lines.splice(sectionEnd - 1, 1);
+    sectionEnd = findGodotIniSectionEnd(lines, sectionIndex + 1);
+  }
+
+  const hasRemainingContent = lines
+    .slice(sectionIndex + 1, sectionEnd)
+    .some(sectionLine => sectionLine.trim() !== '');
+  if (!hasRemainingContent) {
+    lines.splice(sectionIndex, sectionEnd - sectionIndex);
+    if (sectionIndex === lines.length && lines.length > 0 && lines[lines.length - 1].trim() === '') {
+      lines.pop();
+    } else if (
+      sectionIndex > 0 &&
+      sectionIndex < lines.length &&
+      lines[sectionIndex - 1].trim() === '' &&
+      lines[sectionIndex].trim() === ''
+    ) {
+      lines.splice(sectionIndex, 1);
+    }
+  }
+
+  return joinGodotIniLines(lines, newline, parsed.trailingNewline && lines.length > 0);
+}
+
+function splitGodotIniLines(content: string): { lines: string[]; trailingNewline: boolean } {
+  if (content.length === 0) {
+    return { lines: [], trailingNewline: false };
+  }
+
+  const trailingNewline = /\r?\n$/.test(content);
+  const normalized = content.replace(/\r\n/g, '\n');
+  const lines = normalized.split('\n');
+  if (trailingNewline) {
+    lines.pop();
+  }
+  return { lines, trailingNewline };
+}
+
+function joinGodotIniLines(lines: string[], newline: string, trailingNewline: boolean): string {
+  if (lines.length === 0) {
+    return '';
+  }
+  return `${lines.join(newline)}${trailingNewline ? newline : ''}`;
+}
+
+function detectNewline(content: string): string {
+  return content.includes('\r\n') ? '\r\n' : '\n';
+}
+
+function findGodotIniSection(lines: string[], section: string): number {
+  return lines.findIndex(line => line.trim() === `[${section}]`);
+}
+
+function findGodotIniSectionEnd(lines: string[], startIndex: number): number {
+  for (let i = startIndex; i < lines.length; i++) {
+    if (/^\s*\[[^\]]+\]\s*$/.test(lines[i])) {
+      return i;
+    }
+  }
+  return lines.length;
+}
+
+function godotIniLineMatchesKey(line: string, key: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith(';')) {
+    return false;
+  }
+  const match = /^([^=]+)\s*=/.exec(trimmed);
+  return match?.[1].trim() === key;
+}
+
 /**
  * Parse a Godot-style INI file (project.godot, export_presets.cfg, …) into a
  * `{ section: { key: value } }` map. Unlike a naive line-by-line parser this

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -1932,8 +1932,8 @@ describe('Tool dispatch switch statement', () => {
   it('every case returns await this.handle*', () => {
     const caseRegex = /case '(\w+)':\s*\n\s*return await this\.handle/g;
     const matches = [...sourceCode.matchAll(caseRegex)];
-    // Should match all 155 tools
-    expect(matches.length).toBe(155);
+    // Should match all 156 tools
+    expect(matches.length).toBe(156);
   });
 
   it('no case falls through without return', () => {

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -1932,8 +1932,8 @@ describe('Tool dispatch switch statement', () => {
   it('every case returns await this.handle*', () => {
     const caseRegex = /case '(\w+)':\s*\n\s*return await this\.handle/g;
     const matches = [...sourceCode.matchAll(caseRegex)];
-    // Should match all 154 tools
-    expect(matches.length).toBe(154);
+    // Should match all 155 tools
+    expect(matches.length).toBe(155);
   });
 
   it('no case falls through without return', () => {

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -1101,8 +1101,8 @@ describe('Lifecycle handlers', () => {
 
   it('handleReadProjectSettings parses INI-style sections', () => {
     expect(sourceCode).toContain('handleReadProjectSettings');
-    // It should parse [section] headers and key=value pairs
-    expect(sourceCode).toContain("match(/^\\[(.+)\\]$/");
+    // Parsing is delegated to the shared utils.parseGodotIni helper.
+    expect(sourceCode).toContain('parseGodotIni');
   });
 
   it('handleModifyProjectSettings writes to project.godot', () => {

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -1014,7 +1014,7 @@ describe('Handler source structure', () => {
 
   it('headlessOp validates projectPath and checks project.godot', () => {
     expect(sourceCode).toContain("if (!projectPath) return createErrorResponse('projectPath is required.");
-    expect(sourceCode).toContain("if (!validatePath(projectPath)) return createErrorResponse('Invalid path.");
+    expect(sourceCode).toContain("if (!validateProjectPath(projectPath)) return createErrorResponse('Invalid path.");
     expect(sourceCode).toContain("project.godot");
   });
 

--- a/tests/script-templates.test.ts
+++ b/tests/script-templates.test.ts
@@ -2,7 +2,16 @@ import { describe, it, expect } from 'vitest';
 import {
   buildGdScriptTemplate,
   buildCSharpScriptTemplate,
+  type CSharpScriptTemplateArgs,
 } from '../src/script-templates.js';
+
+function cs(opts: Partial<CSharpScriptTemplateArgs> = {}): string {
+  return buildCSharpScriptTemplate({
+    scriptPath: 'P.cs',
+    methods: [],
+    ...opts,
+  });
+}
 
 describe('buildGdScriptTemplate', () => {
   it('emits extends-only template by default', () => {
@@ -29,121 +38,65 @@ describe('buildGdScriptTemplate', () => {
 
 describe('buildCSharpScriptTemplate', () => {
   it('emits using directive and partial class with default Node base', () => {
-    const out = buildCSharpScriptTemplate({ scriptPath: 'src/Player.cs', methods: [] });
+    const out = cs({ scriptPath: 'src/Player.cs' });
     expect(out.startsWith('using Godot;')).toBe(true);
     expect(out).toContain('public partial class Player : Node');
   });
 
-  it('derives the class name from the file basename when none is given', () => {
-    const out = buildCSharpScriptTemplate({ scriptPath: 'scripts/enemy_ai.cs', methods: [] });
-    expect(out).toContain('public partial class EnemyAi : Node');
-  });
-
   it('uses the explicit className when provided', () => {
-    const out = buildCSharpScriptTemplate({
-      scriptPath: 'x.cs',
-      className: 'MyEnemy',
-      methods: [],
-    });
-    expect(out).toContain('public partial class MyEnemy : Node');
+    expect(cs({ scriptPath: 'x.cs', className: 'MyEnemy' })).toContain(
+      'public partial class MyEnemy : Node'
+    );
   });
 
   it('uses the supplied base class', () => {
-    const out = buildCSharpScriptTemplate({
-      scriptPath: 'Player.cs',
-      baseClass: 'CharacterBody3D',
-      methods: [],
-    });
-    expect(out).toContain('public partial class Player : CharacterBody3D');
+    expect(cs({ scriptPath: 'Player.cs', baseClass: 'CharacterBody3D' })).toContain(
+      'public partial class Player : CharacterBody3D'
+    );
   });
 
-  it('renders lifecycle methods as overrides with the right signatures', () => {
-    const out = buildCSharpScriptTemplate({
-      scriptPath: 'Player.cs',
-      methods: ['_ready', '_process', '_input'],
-    });
-    expect(out).toContain('public override void _Ready()');
-    expect(out).toContain('public override void _Process(double delta)');
-    expect(out).toContain('public override void _Input(InputEvent @event)');
+  it.each<[string, string]>([
+    ['scripts/enemy_ai.cs', 'EnemyAi'],
+    ['weird-name!.cs', 'WeirdName'],
+    ['2d-controller.cs', '_2dController'],
+  ])('derives class name %s -> %s', (scriptPath, expected) => {
+    expect(cs({ scriptPath })).toContain(`public partial class ${expected} : Node`);
   });
 
-  it('accepts snake_case lifecycle aliases', () => {
-    const out = buildCSharpScriptTemplate({
-      scriptPath: 'P.cs',
-      methods: ['_physics_process', '_unhandled_input'],
-    });
-    expect(out).toContain('public override void _PhysicsProcess(double delta)');
-    expect(out).toContain('public override void _UnhandledInput(InputEvent @event)');
+  it.each<[string, string]>([
+    ['_ready', 'public override void _Ready()'],
+    ['_process', 'public override void _Process(double delta)'],
+    ['_physics_process', 'public override void _PhysicsProcess(double delta)'],
+    ['_input', 'public override void _Input(InputEvent @event)'],
+    ['_unhandled_input', 'public override void _UnhandledInput(InputEvent @event)'],
+    ['_unhandled_key_input', 'public override void _UnhandledKeyInput(InputEvent @event)'],
+    ['_shortcut_input', 'public override void _ShortcutInput(InputEvent @event)'],
+    ['_gui_input', 'public override void _GuiInput(InputEvent @event)'],
+    ['_enter_tree', 'public override void _EnterTree()'],
+    ['_exit_tree', 'public override void _ExitTree()'],
+    ['_notification', 'public override void _Notification(int what)'],
+    ['_integrate_forces', 'public override void _IntegrateForces(PhysicsDirectBodyState3D state)'],
+    ['_get', 'public override void _Get(StringName property)'],
+    ['_set', 'public override void _Set(StringName property, Variant value)'],
+    ['_get_property_list', 'public override void _GetPropertyList()'],
+    ['_draw', 'public override void _Draw()'],
+  ])('renders lifecycle override for %s', (method, expected) => {
+    expect(cs({ methods: [method] })).toContain(expected);
   });
 
-  it('renders non-lifecycle methods as plain void stubs', () => {
-    const out = buildCSharpScriptTemplate({
-      scriptPath: 'P.cs',
-      methods: ['move', 'takeDamage'],
-    });
-    expect(out).toContain('public void Move()');
-    expect(out).toContain('public void TakeDamage()');
-  });
-
-  it('sanitizes invalid characters in file-derived class names', () => {
-    const out = buildCSharpScriptTemplate({ scriptPath: 'weird-name!.cs', methods: [] });
-    expect(out).toContain('public partial class WeirdName : Node');
-  });
-
-  it('prefixes an underscore when the filename starts with a digit', () => {
-    const out = buildCSharpScriptTemplate({ scriptPath: '2d-controller.cs', methods: [] });
-    expect(out).toContain('public partial class _2dController : Node');
+  it.each<[string, string]>([
+    ['move', 'public void Move()'],
+    ['takeDamage', 'public void TakeDamage()'],
+    ['take_damage', 'public void TakeDamage()'],
+    ['spawn_effect_at_point', 'public void SpawnEffectAtPoint()'],
+    ['_private_helper', 'public void _PrivateHelper()'],
+  ])('renders non-lifecycle method %s as %s', (method, expected) => {
+    expect(cs({ methods: [method] })).toContain(expected);
   });
 
   it('indents method bodies four spaces', () => {
-    const out = buildCSharpScriptTemplate({
-      scriptPath: 'P.cs',
-      methods: ['_ready'],
-    });
+    const out = cs({ methods: ['_ready'] });
     expect(out).toContain('    public override void _Ready()');
     expect(out).toContain('    {\n    }');
-  });
-
-  it('renders the rest of Godot 4 lifecycle overrides', () => {
-    const out = buildCSharpScriptTemplate({
-      scriptPath: 'P.cs',
-      methods: [
-        '_unhandled_key_input',
-        '_shortcut_input',
-        '_gui_input',
-        '_notification',
-        '_integrate_forces',
-        '_get',
-        '_set',
-        '_get_property_list',
-        '_draw',
-      ],
-    });
-    expect(out).toContain('public override void _UnhandledKeyInput(InputEvent @event)');
-    expect(out).toContain('public override void _ShortcutInput(InputEvent @event)');
-    expect(out).toContain('public override void _GuiInput(InputEvent @event)');
-    expect(out).toContain('public override void _Notification(int what)');
-    expect(out).toContain('public override void _IntegrateForces(PhysicsDirectBodyState3D state)');
-    expect(out).toContain('public override void _Get(StringName property)');
-    expect(out).toContain('public override void _Set(StringName property, Variant value)');
-    expect(out).toContain('public override void _GetPropertyList()');
-    expect(out).toContain('public override void _Draw()');
-  });
-
-  it('converts snake_case custom methods to PascalCase across all segments', () => {
-    const out = buildCSharpScriptTemplate({
-      scriptPath: 'P.cs',
-      methods: ['take_damage', 'spawn_effect_at_point'],
-    });
-    expect(out).toContain('public void TakeDamage()');
-    expect(out).toContain('public void SpawnEffectAtPoint()');
-  });
-
-  it('preserves the leading underscore on non-lifecycle "_"-prefixed methods', () => {
-    const out = buildCSharpScriptTemplate({
-      scriptPath: 'P.cs',
-      methods: ['_private_helper'],
-    });
-    expect(out).toContain('public void _PrivateHelper()');
   });
 });

--- a/tests/script-templates.test.ts
+++ b/tests/script-templates.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildGdScriptTemplate,
+  buildCSharpScriptTemplate,
+} from '../src/script-templates.js';
+
+describe('buildGdScriptTemplate', () => {
+  it('emits extends-only template by default', () => {
+    expect(buildGdScriptTemplate({ methods: [] })).toBe('extends Node\n');
+  });
+
+  it('uses supplied base class', () => {
+    expect(buildGdScriptTemplate({ baseClass: 'CharacterBody2D', methods: [] })).toContain(
+      'extends CharacterBody2D'
+    );
+  });
+
+  it('places class_name before extends', () => {
+    const out = buildGdScriptTemplate({ className: 'Player', baseClass: 'Node', methods: [] });
+    expect(out.indexOf('class_name Player')).toBeLessThan(out.indexOf('extends Node'));
+  });
+
+  it('renders method stubs with pass body', () => {
+    const out = buildGdScriptTemplate({ methods: ['_ready', 'move'] });
+    expect(out).toContain('func _ready():\n\tpass');
+    expect(out).toContain('func move():\n\tpass');
+  });
+});
+
+describe('buildCSharpScriptTemplate', () => {
+  it('emits using directive and partial class with default Node base', () => {
+    const out = buildCSharpScriptTemplate({ scriptPath: 'src/Player.cs', methods: [] });
+    expect(out.startsWith('using Godot;')).toBe(true);
+    expect(out).toContain('public partial class Player : Node');
+  });
+
+  it('derives the class name from the file basename when none is given', () => {
+    const out = buildCSharpScriptTemplate({ scriptPath: 'scripts/enemy_ai.cs', methods: [] });
+    expect(out).toContain('public partial class Enemy_ai : Node');
+  });
+
+  it('uses the explicit className when provided', () => {
+    const out = buildCSharpScriptTemplate({
+      scriptPath: 'x.cs',
+      className: 'MyEnemy',
+      methods: [],
+    });
+    expect(out).toContain('public partial class MyEnemy : Node');
+  });
+
+  it('uses the supplied base class', () => {
+    const out = buildCSharpScriptTemplate({
+      scriptPath: 'Player.cs',
+      baseClass: 'CharacterBody3D',
+      methods: [],
+    });
+    expect(out).toContain('public partial class Player : CharacterBody3D');
+  });
+
+  it('renders lifecycle methods as overrides with the right signatures', () => {
+    const out = buildCSharpScriptTemplate({
+      scriptPath: 'Player.cs',
+      methods: ['_ready', '_process', '_input'],
+    });
+    expect(out).toContain('public override void _Ready()');
+    expect(out).toContain('public override void _Process(double delta)');
+    expect(out).toContain('public override void _Input(InputEvent @event)');
+  });
+
+  it('accepts snake_case lifecycle aliases', () => {
+    const out = buildCSharpScriptTemplate({
+      scriptPath: 'P.cs',
+      methods: ['_physics_process', '_unhandled_input'],
+    });
+    expect(out).toContain('public override void _PhysicsProcess(double delta)');
+    expect(out).toContain('public override void _UnhandledInput(InputEvent @event)');
+  });
+
+  it('renders non-lifecycle methods as plain void stubs', () => {
+    const out = buildCSharpScriptTemplate({
+      scriptPath: 'P.cs',
+      methods: ['move', 'takeDamage'],
+    });
+    expect(out).toContain('public void Move()');
+    expect(out).toContain('public void TakeDamage()');
+  });
+
+  it('sanitizes invalid characters in file-derived class names', () => {
+    const out = buildCSharpScriptTemplate({ scriptPath: 'weird-name!.cs', methods: [] });
+    expect(out).toContain('public partial class Weird_name_ : Node');
+  });
+
+  it('prefixes an underscore when the filename starts with a digit', () => {
+    const out = buildCSharpScriptTemplate({ scriptPath: '2d-controller.cs', methods: [] });
+    expect(out).toContain('public partial class _2d_controller : Node');
+  });
+
+  it('indents method bodies four spaces', () => {
+    const out = buildCSharpScriptTemplate({
+      scriptPath: 'P.cs',
+      methods: ['_ready'],
+    });
+    expect(out).toContain('    public override void _Ready()');
+    expect(out).toContain('    {\n    }');
+  });
+});

--- a/tests/script-templates.test.ts
+++ b/tests/script-templates.test.ts
@@ -36,7 +36,7 @@ describe('buildCSharpScriptTemplate', () => {
 
   it('derives the class name from the file basename when none is given', () => {
     const out = buildCSharpScriptTemplate({ scriptPath: 'scripts/enemy_ai.cs', methods: [] });
-    expect(out).toContain('public partial class Enemy_ai : Node');
+    expect(out).toContain('public partial class EnemyAi : Node');
   });
 
   it('uses the explicit className when provided', () => {
@@ -87,12 +87,12 @@ describe('buildCSharpScriptTemplate', () => {
 
   it('sanitizes invalid characters in file-derived class names', () => {
     const out = buildCSharpScriptTemplate({ scriptPath: 'weird-name!.cs', methods: [] });
-    expect(out).toContain('public partial class Weird_name_ : Node');
+    expect(out).toContain('public partial class WeirdName : Node');
   });
 
   it('prefixes an underscore when the filename starts with a digit', () => {
     const out = buildCSharpScriptTemplate({ scriptPath: '2d-controller.cs', methods: [] });
-    expect(out).toContain('public partial class _2d_controller : Node');
+    expect(out).toContain('public partial class _2dController : Node');
   });
 
   it('indents method bodies four spaces', () => {
@@ -102,5 +102,48 @@ describe('buildCSharpScriptTemplate', () => {
     });
     expect(out).toContain('    public override void _Ready()');
     expect(out).toContain('    {\n    }');
+  });
+
+  it('renders the rest of Godot 4 lifecycle overrides', () => {
+    const out = buildCSharpScriptTemplate({
+      scriptPath: 'P.cs',
+      methods: [
+        '_unhandled_key_input',
+        '_shortcut_input',
+        '_gui_input',
+        '_notification',
+        '_integrate_forces',
+        '_get',
+        '_set',
+        '_get_property_list',
+        '_draw',
+      ],
+    });
+    expect(out).toContain('public override void _UnhandledKeyInput(InputEvent @event)');
+    expect(out).toContain('public override void _ShortcutInput(InputEvent @event)');
+    expect(out).toContain('public override void _GuiInput(InputEvent @event)');
+    expect(out).toContain('public override void _Notification(int what)');
+    expect(out).toContain('public override void _IntegrateForces(PhysicsDirectBodyState3D state)');
+    expect(out).toContain('public override void _Get(StringName property)');
+    expect(out).toContain('public override void _Set(StringName property, Variant value)');
+    expect(out).toContain('public override void _GetPropertyList()');
+    expect(out).toContain('public override void _Draw()');
+  });
+
+  it('converts snake_case custom methods to PascalCase across all segments', () => {
+    const out = buildCSharpScriptTemplate({
+      scriptPath: 'P.cs',
+      methods: ['take_damage', 'spawn_effect_at_point'],
+    });
+    expect(out).toContain('public void TakeDamage()');
+    expect(out).toContain('public void SpawnEffectAtPoint()');
+  });
+
+  it('preserves the leading underscore on non-lifecycle "_"-prefixed methods', () => {
+    const out = buildCSharpScriptTemplate({
+      scriptPath: 'P.cs',
+      methods: ['_private_helper'],
+    });
+    expect(out).toContain('public void _PrivateHelper()');
   });
 });

--- a/tests/tool-filter.test.ts
+++ b/tests/tool-filter.test.ts
@@ -107,8 +107,9 @@ describe('ToolFilter', () => {
     it('includes only tools carrying at least one matching tag', () => {
       const filter = new ToolFilter({ enabledTags: ['gdscript-only'] });
       const out = filter.filter(TOOLS);
-      expect(names(out).sort()).toEqual(
-        ['game_eval', 'create_script', 'attach_script', 'game_script'].sort()
+      const byName = (a: string, b: string) => a.localeCompare(b);
+      expect(names(out).sort(byName)).toEqual(
+        ['game_eval', 'create_script', 'attach_script', 'game_script'].sort(byName)
       );
     });
 
@@ -157,6 +158,13 @@ describe('ToolFilter', () => {
 
   describe('ToolFilter.load', () => {
     let tmpDir: string;
+    const writeConfig = (contents: string | object): string => {
+      const p = join(tmpDir, 'config.json');
+      writeFileSync(p, typeof contents === 'string' ? contents : JSON.stringify(contents));
+      return p;
+    };
+    const loadedNames = (env: NodeJS.ProcessEnv): string[] =>
+      names(ToolFilter.load(env).filter(TOOLS));
 
     beforeEach(() => {
       tmpDir = mkdtempSync(join(tmpdir(), 'godot-mcp-test-'));
@@ -167,103 +175,61 @@ describe('ToolFilter', () => {
     });
 
     it('returns default filter when no env vars are set', () => {
-      const filter = ToolFilter.load({});
-      const out = filter.filter(TOOLS);
-      expect(names(out)).toEqual(names(TOOLS));
+      expect(loadedNames({})).toEqual(names(TOOLS));
     });
 
     it('reads a JSON config file', () => {
-      const path = join(tmpDir, 'config.json');
-      writeFileSync(
-        path,
-        JSON.stringify({ disabledTags: ['gdscript-only'] })
-      );
-      const filter = ToolFilter.load({ GODOT_MCP_CONFIG: path });
-      const out = filter.filter(TOOLS);
-      expect(names(out)).not.toContain('game_eval');
-      expect(names(out)).toContain('launch_editor');
+      const path = writeConfig({ disabledTags: ['gdscript-only'] });
+      const out = loadedNames({ GODOT_MCP_CONFIG: path });
+      expect(out).not.toContain('game_eval');
+      expect(out).toContain('launch_editor');
     });
 
     it('parses comma-separated env vars', () => {
-      const filter = ToolFilter.load({
-        GODOT_MCP_DISABLED_TOOLS: 'game_eval, create_script ,attach_script,game_script',
-      });
-      const out = filter.filter(TOOLS);
-      expect(names(out)).toEqual(['launch_editor', 'run_project', 'headless_only_tool']);
+      expect(
+        loadedNames({
+          GODOT_MCP_DISABLED_TOOLS: 'game_eval, create_script ,attach_script,game_script',
+        })
+      ).toEqual(['launch_editor', 'run_project', 'headless_only_tool']);
     });
 
     it('env vars replace file fields per-field', () => {
-      const path = join(tmpDir, 'config.json');
-      writeFileSync(
-        path,
-        JSON.stringify({
-          disabledTools: ['launch_editor'],
-          disabledTags: ['gdscript-only'],
-        })
-      );
-      const filter = ToolFilter.load({
+      const path = writeConfig({
+        disabledTools: ['launch_editor'],
+        disabledTags: ['gdscript-only'],
+      });
+      const out = loadedNames({
         GODOT_MCP_CONFIG: path,
         GODOT_MCP_DISABLED_TOOLS: 'run_project',
       });
-      const out = filter.filter(TOOLS);
-      // disabledTools was replaced (launch_editor allowed again, run_project excluded)
-      // disabledTags from file is preserved (gdscript-only tools still excluded)
-      expect(names(out)).toContain('launch_editor');
-      expect(names(out)).not.toContain('run_project');
-      expect(names(out)).not.toContain('game_eval');
+      // disabledTools was replaced (launch_editor allowed again, run_project excluded);
+      // disabledTags from file is preserved (gdscript-only tools still excluded).
+      expect(out).toContain('launch_editor');
+      expect(out).not.toContain('run_project');
+      expect(out).not.toContain('game_eval');
     });
 
-    it('throws on missing config file', () => {
-      expect(() =>
-        ToolFilter.load({ GODOT_MCP_CONFIG: join(tmpDir, 'nope.json') })
-      ).toThrow(/not found/);
+    it.each<[string, string | object, RegExp]>([
+      ['missing config file', '__absent__', /not found/],
+      ['invalid JSON', '{ not valid json', /not valid JSON/],
+      ['non-object root', '["a", "b"]', /must be a JSON object/],
+      ['field not an array of strings', { disabledTools: 'game_eval' }, /array of strings/],
+    ])('throws on %s', (_label, contents, errorPattern) => {
+      const path =
+        contents === '__absent__' ? join(tmpDir, 'nope.json') : writeConfig(contents);
+      expect(() => ToolFilter.load({ GODOT_MCP_CONFIG: path })).toThrow(errorPattern);
     });
 
-    it('throws on invalid JSON', () => {
-      const path = join(tmpDir, 'bad.json');
-      writeFileSync(path, '{ not valid json');
-      expect(() => ToolFilter.load({ GODOT_MCP_CONFIG: path })).toThrow(
-        /not valid JSON/
-      );
-    });
-
-    it('throws when config file root is not an object', () => {
-      const path = join(tmpDir, 'arr.json');
-      writeFileSync(path, '["a", "b"]');
-      expect(() => ToolFilter.load({ GODOT_MCP_CONFIG: path })).toThrow(
-        /must be a JSON object/
-      );
-    });
-
-    it('throws when a field is not an array of strings', () => {
-      const path = join(tmpDir, 'wrong.json');
-      writeFileSync(path, JSON.stringify({ disabledTools: 'game_eval' }));
-      expect(() => ToolFilter.load({ GODOT_MCP_CONFIG: path })).toThrow(
-        /array of strings/
-      );
-    });
-
-    it('treats an empty env-var as unset so it does not wipe a JSON-configured field', () => {
-      const path = join(tmpDir, 'config.json');
-      writeFileSync(path, JSON.stringify({ disabledTools: ['game_eval'] }));
-      const filter = ToolFilter.load({
+    it.each<[string, string]>([
+      ['empty', ''],
+      ['whitespace-only', '  ,  , '],
+    ])('treats %s env-var as unset (does not wipe JSON-configured field)', (_label, envValue) => {
+      const path = writeConfig({ disabledTools: ['game_eval'] });
+      const out = loadedNames({
         GODOT_MCP_CONFIG: path,
-        GODOT_MCP_DISABLED_TOOLS: '',
+        GODOT_MCP_DISABLED_TOOLS: envValue,
       });
-      const out = filter.filter(TOOLS);
-      // Empty string is treated as unset, so the JSON denylist still applies.
-      expect(names(out)).not.toContain('game_eval');
-    });
-
-    it('treats a whitespace-only env-var as unset', () => {
-      const path = join(tmpDir, 'config.json');
-      writeFileSync(path, JSON.stringify({ disabledTools: ['game_eval'] }));
-      const filter = ToolFilter.load({
-        GODOT_MCP_CONFIG: path,
-        GODOT_MCP_DISABLED_TOOLS: '  ,  , ',
-      });
-      const out = filter.filter(TOOLS);
-      expect(names(out)).not.toContain('game_eval');
+      expect(out).not.toContain('game_eval');
     });
   });
 });

--- a/tests/tool-filter.test.ts
+++ b/tests/tool-filter.test.ts
@@ -243,7 +243,7 @@ describe('ToolFilter', () => {
       );
     });
 
-    it('treats empty env-var as an empty list, clearing the file field', () => {
+    it('treats an empty env-var as unset so it does not wipe a JSON-configured field', () => {
       const path = join(tmpDir, 'config.json');
       writeFileSync(path, JSON.stringify({ disabledTools: ['game_eval'] }));
       const filter = ToolFilter.load({
@@ -251,7 +251,19 @@ describe('ToolFilter', () => {
         GODOT_MCP_DISABLED_TOOLS: '',
       });
       const out = filter.filter(TOOLS);
-      expect(names(out)).toContain('game_eval');
+      // Empty string is treated as unset, so the JSON denylist still applies.
+      expect(names(out)).not.toContain('game_eval');
+    });
+
+    it('treats a whitespace-only env-var as unset', () => {
+      const path = join(tmpDir, 'config.json');
+      writeFileSync(path, JSON.stringify({ disabledTools: ['game_eval'] }));
+      const filter = ToolFilter.load({
+        GODOT_MCP_CONFIG: path,
+        GODOT_MCP_DISABLED_TOOLS: '  ,  , ',
+      });
+      const out = filter.filter(TOOLS);
+      expect(names(out)).not.toContain('game_eval');
     });
   });
 });

--- a/tests/tool-filter.test.ts
+++ b/tests/tool-filter.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { ToolFilter, type ToolDef } from '../src/tool-filter.js';
 
 const TOOLS: ToolDef[] = [

--- a/tests/tool-filter.test.ts
+++ b/tests/tool-filter.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ToolFilter, type ToolDef } from '../src/tool-filter.js';
+
+const TOOLS: ToolDef[] = [
+  { name: 'launch_editor', description: 'd', inputSchema: {} },
+  { name: 'run_project', description: 'd', inputSchema: {} },
+  { name: 'game_eval', description: 'd', inputSchema: {}, tags: ['gdscript-only'] },
+  { name: 'create_script', description: 'd', inputSchema: {}, tags: ['gdscript-only'] },
+  { name: 'attach_script', description: 'd', inputSchema: {}, tags: ['gdscript-only'] },
+  { name: 'game_script', description: 'd', inputSchema: {}, tags: ['gdscript-only'] },
+  { name: 'headless_only_tool', description: 'd', inputSchema: {}, tags: ['headless-only'] },
+];
+
+function names(tools: ToolDef[]): string[] {
+  return tools.map((t) => t.name);
+}
+
+describe('ToolFilter', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe('default (no config)', () => {
+    it('enables every tool', () => {
+      const filter = new ToolFilter();
+      const out = filter.filter(TOOLS);
+      expect(names(out)).toEqual(names(TOOLS));
+    });
+
+    it('isEnabled returns true for every tool after filter()', () => {
+      const filter = new ToolFilter();
+      filter.filter(TOOLS);
+      for (const t of TOOLS) {
+        expect(filter.isEnabled(t.name)).toBe(true);
+      }
+    });
+
+    it('isEnabled throws before filter() is called', () => {
+      const filter = new ToolFilter();
+      expect(() => filter.isEnabled('launch_editor')).toThrow(
+        /called before filter/
+      );
+    });
+  });
+
+  describe('disabledTools', () => {
+    it('excludes named tools', () => {
+      const filter = new ToolFilter({ disabledTools: ['game_eval', 'create_script'] });
+      const out = filter.filter(TOOLS);
+      expect(names(out)).not.toContain('game_eval');
+      expect(names(out)).not.toContain('create_script');
+      expect(names(out)).toContain('launch_editor');
+      expect(filter.isEnabled('game_eval')).toBe(false);
+      expect(filter.isEnabled('launch_editor')).toBe(true);
+    });
+  });
+
+  describe('enabledTools', () => {
+    it('includes only named tools', () => {
+      const filter = new ToolFilter({ enabledTools: ['launch_editor', 'run_project'] });
+      const out = filter.filter(TOOLS);
+      expect(names(out)).toEqual(['launch_editor', 'run_project']);
+    });
+
+    it('excludes tools not in allowlist', () => {
+      const filter = new ToolFilter({ enabledTools: ['launch_editor'] });
+      filter.filter(TOOLS);
+      expect(filter.isEnabled('game_eval')).toBe(false);
+    });
+  });
+
+  describe('denylist wins over allowlist', () => {
+    it('excludes tool listed in both', () => {
+      const filter = new ToolFilter({
+        enabledTools: ['launch_editor', 'game_eval'],
+        disabledTools: ['game_eval'],
+      });
+      const out = filter.filter(TOOLS);
+      expect(names(out)).toEqual(['launch_editor']);
+    });
+  });
+
+  describe('disabledTags', () => {
+    it('excludes tools carrying any matching tag', () => {
+      const filter = new ToolFilter({ disabledTags: ['gdscript-only'] });
+      const out = filter.filter(TOOLS);
+      expect(names(out)).toEqual(['launch_editor', 'run_project', 'headless_only_tool']);
+    });
+
+    it('does not exclude untagged tools', () => {
+      const filter = new ToolFilter({ disabledTags: ['gdscript-only'] });
+      filter.filter(TOOLS);
+      expect(filter.isEnabled('launch_editor')).toBe(true);
+    });
+  });
+
+  describe('enabledTags', () => {
+    it('includes only tools carrying at least one matching tag', () => {
+      const filter = new ToolFilter({ enabledTags: ['gdscript-only'] });
+      const out = filter.filter(TOOLS);
+      expect(names(out).sort()).toEqual(
+        ['game_eval', 'create_script', 'attach_script', 'game_script'].sort()
+      );
+    });
+
+    it('excludes untagged tools', () => {
+      const filter = new ToolFilter({ enabledTags: ['gdscript-only'] });
+      filter.filter(TOOLS);
+      expect(filter.isEnabled('launch_editor')).toBe(false);
+    });
+  });
+
+  describe('combined tag rules', () => {
+    it('denylist tag overrides enabledTools entry', () => {
+      const filter = new ToolFilter({
+        enabledTools: ['launch_editor', 'game_eval'],
+        disabledTags: ['gdscript-only'],
+      });
+      const out = filter.filter(TOOLS);
+      expect(names(out)).toEqual(['launch_editor']);
+    });
+  });
+
+  describe('unknown-name warnings', () => {
+    it('warns on unknown tool names in disabledTools', () => {
+      const filter = new ToolFilter({ disabledTools: ['does_not_exist'] });
+      filter.filter(TOOLS);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('unknown disabledTools: does_not_exist')
+      );
+    });
+
+    it('warns on unknown tags in disabledTags', () => {
+      const filter = new ToolFilter({ disabledTags: ['unknown-tag'] });
+      filter.filter(TOOLS);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('unknown disabledTags: unknown-tag')
+      );
+    });
+
+    it('does not warn for known names', () => {
+      const filter = new ToolFilter({ disabledTools: ['game_eval'] });
+      filter.filter(TOOLS);
+      const calls = warnSpy.mock.calls.map((c) => String(c[0]));
+      expect(calls.some((c) => c.includes('unknown'))).toBe(false);
+    });
+  });
+
+  describe('ToolFilter.load', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'godot-mcp-test-'));
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('returns default filter when no env vars are set', () => {
+      const filter = ToolFilter.load({});
+      const out = filter.filter(TOOLS);
+      expect(names(out)).toEqual(names(TOOLS));
+    });
+
+    it('reads a JSON config file', () => {
+      const path = join(tmpDir, 'config.json');
+      writeFileSync(
+        path,
+        JSON.stringify({ disabledTags: ['gdscript-only'] })
+      );
+      const filter = ToolFilter.load({ GODOT_MCP_CONFIG: path });
+      const out = filter.filter(TOOLS);
+      expect(names(out)).not.toContain('game_eval');
+      expect(names(out)).toContain('launch_editor');
+    });
+
+    it('parses comma-separated env vars', () => {
+      const filter = ToolFilter.load({
+        GODOT_MCP_DISABLED_TOOLS: 'game_eval, create_script ,attach_script,game_script',
+      });
+      const out = filter.filter(TOOLS);
+      expect(names(out)).toEqual(['launch_editor', 'run_project', 'headless_only_tool']);
+    });
+
+    it('env vars replace file fields per-field', () => {
+      const path = join(tmpDir, 'config.json');
+      writeFileSync(
+        path,
+        JSON.stringify({
+          disabledTools: ['launch_editor'],
+          disabledTags: ['gdscript-only'],
+        })
+      );
+      const filter = ToolFilter.load({
+        GODOT_MCP_CONFIG: path,
+        GODOT_MCP_DISABLED_TOOLS: 'run_project',
+      });
+      const out = filter.filter(TOOLS);
+      // disabledTools was replaced (launch_editor allowed again, run_project excluded)
+      // disabledTags from file is preserved (gdscript-only tools still excluded)
+      expect(names(out)).toContain('launch_editor');
+      expect(names(out)).not.toContain('run_project');
+      expect(names(out)).not.toContain('game_eval');
+    });
+
+    it('throws on missing config file', () => {
+      expect(() =>
+        ToolFilter.load({ GODOT_MCP_CONFIG: join(tmpDir, 'nope.json') })
+      ).toThrow(/not found/);
+    });
+
+    it('throws on invalid JSON', () => {
+      const path = join(tmpDir, 'bad.json');
+      writeFileSync(path, '{ not valid json');
+      expect(() => ToolFilter.load({ GODOT_MCP_CONFIG: path })).toThrow(
+        /not valid JSON/
+      );
+    });
+
+    it('throws when config file root is not an object', () => {
+      const path = join(tmpDir, 'arr.json');
+      writeFileSync(path, '["a", "b"]');
+      expect(() => ToolFilter.load({ GODOT_MCP_CONFIG: path })).toThrow(
+        /must be a JSON object/
+      );
+    });
+
+    it('throws when a field is not an array of strings', () => {
+      const path = join(tmpDir, 'wrong.json');
+      writeFileSync(path, JSON.stringify({ disabledTools: 'game_eval' }));
+      expect(() => ToolFilter.load({ GODOT_MCP_CONFIG: path })).toThrow(
+        /array of strings/
+      );
+    });
+
+    it('treats empty env-var as an empty list, clearing the file field', () => {
+      const path = join(tmpDir, 'config.json');
+      writeFileSync(path, JSON.stringify({ disabledTools: ['game_eval'] }));
+      const filter = ToolFilter.load({
+        GODOT_MCP_CONFIG: path,
+        GODOT_MCP_DISABLED_TOOLS: '',
+      });
+      const out = filter.filter(TOOLS);
+      expect(names(out)).toContain('game_eval');
+    });
+  });
+});

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -499,7 +499,7 @@ describe('parseGodotIni', () => {
       expect(removeGodotIniSectionLine(injected, 'autoload', 'McpInteractionServer')).toBe(original);
     });
 
-    it('removes injected blank lines around an autoload entry when other entries remain', () => {
+    it('preserves surrounding whitespace when other entries remain', () => {
       const content =
         `[autoload]\n` +
         `\n` +
@@ -508,8 +508,50 @@ describe('parseGodotIni', () => {
 
       expect(removeGodotIniSectionLine(content, 'autoload', 'McpInteractionServer')).toBe(
         `[autoload]\n` +
+          `\n` +
           `Globals="*res://globals.gd"\n`
       );
+    });
+
+    it('round-trips byte-for-byte against Godot formatting with other entries', () => {
+      // Godot keeps a blank line after each section header and before the next
+      // section. Injecting then removing the autoload must leave the file
+      // identical so there is no git churn.
+      const original =
+        `[application]\n` +
+        `\n` +
+        `config/name="Game"\n` +
+        `\n` +
+        `[autoload]\n` +
+        `\n` +
+        `Globals="*res://globals.gd"\n` +
+        `\n` +
+        `[rendering]\n` +
+        `\n` +
+        `renderer/rendering_method="gl_compatibility"\n`;
+
+      const injected = addGodotIniSectionLine(
+        original,
+        'autoload',
+        autoloadLine,
+        'McpInteractionServer'
+      );
+
+      expect(injected).toBe(
+        `[application]\n` +
+          `\n` +
+          `config/name="Game"\n` +
+          `\n` +
+          `[autoload]\n` +
+          `\n` +
+          `Globals="*res://globals.gd"\n` +
+          `${autoloadLine}\n` +
+          `\n` +
+          `[rendering]\n` +
+          `\n` +
+          `renderer/rendering_method="gl_compatibility"\n`
+      );
+      expect(removeGodotIniSectionLine(injected, 'autoload', 'McpInteractionServer')).toBe(original);
     });
 
     it('only removes matching keys from the target section', () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -13,6 +13,8 @@ import {
   projectGodotFile,
   projectFilePath,
   toWindowsAccessiblePath,
+  addGodotIniSectionLine,
+  removeGodotIniSectionLine,
   parseGodotIni,
 } from '../src/utils.js';
 
@@ -448,6 +450,62 @@ describe('toWindowsAccessiblePath', () => {
 });
 
 describe('parseGodotIni', () => {
+  describe('Godot INI section line helpers', () => {
+    const autoloadLine = 'McpInteractionServer="*res://mcp_interaction_server.gd"';
+
+    it('round-trips an injected autoload without leaving whitespace', () => {
+      const original = `[application]\nconfig/name="Game"\n`;
+      const injected = addGodotIniSectionLine(
+        original,
+        'autoload',
+        autoloadLine,
+        'McpInteractionServer'
+      );
+
+      expect(injected).toBe(
+        `[application]\n` +
+          `config/name="Game"\n` +
+          `\n` +
+          `[autoload]\n` +
+          `${autoloadLine}\n`
+      );
+      expect(removeGodotIniSectionLine(injected, 'autoload', 'McpInteractionServer')).toBe(original);
+    });
+
+    it('removes injected blank lines around an autoload entry when other entries remain', () => {
+      const content =
+        `[autoload]\n` +
+        `\n` +
+        `${autoloadLine}\n` +
+        `Globals="*res://globals.gd"\n`;
+
+      expect(removeGodotIniSectionLine(content, 'autoload', 'McpInteractionServer')).toBe(
+        `[autoload]\n` +
+          `Globals="*res://globals.gd"\n`
+      );
+    });
+
+    it('only removes matching keys from the target section', () => {
+      const content =
+        `[application]\n` +
+        `McpInteractionServer="not an autoload"\n` +
+        `\n` +
+        `[autoload]\n` +
+        `${autoloadLine}\n`;
+
+      expect(removeGodotIniSectionLine(content, 'autoload', 'McpInteractionServer')).toBe(
+        `[application]\n` +
+          `McpInteractionServer="not an autoload"\n`
+      );
+    });
+
+    it('does not duplicate an existing autoload key', () => {
+      const content = `[autoload]\n${autoloadLine}\n`;
+
+      expect(addGodotIniSectionLine(content, 'autoload', autoloadLine, 'McpInteractionServer')).toBe(content);
+    });
+  });
+
   it('parses a simple flat section', () => {
     const out = parseGodotIni(
       `[application]\n` +

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -250,7 +250,7 @@ describe('WSL path translation', () => {
     });
 
     it('toWslProjectPath converts Windows backslashes too', () => {
-      expect(toWslProjectPath('C:\\Users\\me\\game')).toBe('/mnt/c/Users/me/game');
+      expect(toWslProjectPath(String.raw`C:\Users\me\game`)).toBe('/mnt/c/Users/me/game');
     });
 
     it('toWslProjectPath passes /mnt/ paths through', () => {
@@ -385,7 +385,7 @@ describe('toWindowsAccessiblePath', () => {
   it('converts /home/... to WSL UNC form for Godot.exe', () => {
     process.env.WSL_DISTRO_NAME = 'Ubuntu';
     expect(toWindowsAccessiblePath('/home/me/script.gd', 'C:/Godot/Godot.exe')).toBe(
-      '\\\\wsl.localhost\\Ubuntu\\home\\me\\script.gd'
+      String.raw`\\wsl.localhost\Ubuntu\home\me\script.gd`
     );
   });
 
@@ -422,9 +422,8 @@ describe('toWindowsAccessiblePath', () => {
   });
 
   it('passes an already-UNC path through unchanged', () => {
-    expect(
-      toWindowsAccessiblePath('\\\\wsl.localhost\\Ubuntu\\home\\me', 'C:/Godot/Godot.exe')
-    ).toBe('\\\\wsl.localhost\\Ubuntu\\home\\me');
+    const unc = String.raw`\\wsl.localhost\Ubuntu\home\me`;
+    expect(toWindowsAccessiblePath(unc, 'C:/Godot/Godot.exe')).toBe(unc);
   });
 
   it('passes a bare drive letter through unchanged', () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import {
   PARAMETER_MAPPINGS,
   REVERSE_PARAMETER_MAPPINGS,
@@ -7,6 +7,12 @@ import {
   validatePath,
   createErrorResponse,
   isGodot44OrLater,
+  toWslProjectPath,
+  toNativeProjectPath,
+  isWindowsGodotExe,
+  projectGodotFile,
+  toWindowsAccessiblePath,
+  parseGodotIni,
 } from '../src/utils.js';
 
 describe('PARAMETER_MAPPINGS', () => {
@@ -223,5 +229,256 @@ describe('isGodot44OrLater', () => {
   it('handles version strings with extra info', () => {
     expect(isGodot44OrLater('4.4.1.stable')).toBe(true);
     expect(isGodot44OrLater('4.3.2.rc1')).toBe(false);
+  });
+});
+
+describe('WSL path translation', () => {
+  const origPlatform = process.platform;
+  const setPlatform = (p: NodeJS.Platform) => {
+    Object.defineProperty(process, 'platform', { value: p, configurable: true });
+  };
+
+  afterEach(() => setPlatform(origPlatform));
+
+  describe('on linux', () => {
+    beforeEach(() => setPlatform('linux'));
+
+    it('toWslProjectPath converts C:/... to /mnt/c/...', () => {
+      expect(toWslProjectPath('C:/Users/me/game')).toBe('/mnt/c/Users/me/game');
+      expect(toWslProjectPath('D:/projects/x')).toBe('/mnt/d/projects/x');
+    });
+
+    it('toWslProjectPath converts Windows backslashes too', () => {
+      expect(toWslProjectPath('C:\\Users\\me\\game')).toBe('/mnt/c/Users/me/game');
+    });
+
+    it('toWslProjectPath passes /mnt/ paths through', () => {
+      expect(toWslProjectPath('/mnt/c/Users/me')).toBe('/mnt/c/Users/me');
+    });
+
+    it('toWslProjectPath passes linux-native paths through', () => {
+      expect(toWslProjectPath('/home/joachima/game')).toBe('/home/joachima/game');
+    });
+
+    it('toNativeProjectPath converts /mnt/c/... to C:/...', () => {
+      expect(toNativeProjectPath('/mnt/c/Users/me/game')).toBe('C:/Users/me/game');
+      expect(toNativeProjectPath('/mnt/d/x')).toBe('D:/x');
+    });
+
+    it('toNativeProjectPath passes non-mount paths through', () => {
+      expect(toNativeProjectPath('/home/joachima/game')).toBe('/home/joachima/game');
+    });
+
+    it('toNativeProjectPath passes Windows paths through unchanged', () => {
+      expect(toNativeProjectPath('C:/foo')).toBe('C:/foo');
+    });
+  });
+
+  describe('on non-linux', () => {
+    beforeEach(() => setPlatform('darwin'));
+
+    it('toWslProjectPath is a no-op', () => {
+      expect(toWslProjectPath('C:/Users/me')).toBe('C:/Users/me');
+      expect(toWslProjectPath('/Users/me')).toBe('/Users/me');
+    });
+
+    it('toNativeProjectPath is a no-op', () => {
+      expect(toNativeProjectPath('/mnt/c/foo')).toBe('/mnt/c/foo');
+    });
+  });
+
+  describe('empty / falsy paths', () => {
+    it('returns the input unchanged', () => {
+      expect(toWslProjectPath('')).toBe('');
+      expect(toNativeProjectPath('')).toBe('');
+    });
+  });
+});
+
+describe('isWindowsGodotExe', () => {
+  it('is true for .exe paths', () => {
+    expect(isWindowsGodotExe('C:/Program Files/Godot/Godot.exe')).toBe(true);
+    expect(isWindowsGodotExe('godot.EXE')).toBe(true);
+  });
+
+  it('is false for linux / unix binaries', () => {
+    expect(isWindowsGodotExe('/usr/bin/godot')).toBe(false);
+    expect(isWindowsGodotExe('godot')).toBe(false);
+  });
+
+  it('is false for null / undefined / empty', () => {
+    expect(isWindowsGodotExe(null)).toBe(false);
+    expect(isWindowsGodotExe(undefined)).toBe(false);
+    expect(isWindowsGodotExe('')).toBe(false);
+  });
+});
+
+describe('projectGodotFile', () => {
+  const origPlatform = process.platform;
+  const setPlatform = (p: NodeJS.Platform) => {
+    Object.defineProperty(process, 'platform', { value: p, configurable: true });
+  };
+  afterEach(() => setPlatform(origPlatform));
+
+  it('joins a WSL-translated project path with project.godot on linux', () => {
+    setPlatform('linux');
+    expect(projectGodotFile('C:/Users/me/game')).toBe('/mnt/c/Users/me/game/project.godot');
+  });
+
+  it('passes a native project path through on linux', () => {
+    setPlatform('linux');
+    expect(projectGodotFile('/home/me/game')).toBe('/home/me/game/project.godot');
+  });
+
+  it('joins as-is on non-linux', () => {
+    setPlatform('win32');
+    // win32 path.join uses backslashes — just check it ends with project.godot
+    expect(projectGodotFile('C:/Users/me/game')).toMatch(/project\.godot$/);
+  });
+});
+
+describe('toWindowsAccessiblePath', () => {
+  const origPlatform = process.platform;
+  const origDistro = process.env.WSL_DISTRO_NAME;
+  const setPlatform = (p: NodeJS.Platform) => {
+    Object.defineProperty(process, 'platform', { value: p, configurable: true });
+  };
+
+  beforeEach(() => setPlatform('linux'));
+  afterEach(() => {
+    setPlatform(origPlatform);
+    if (origDistro === undefined) delete process.env.WSL_DISTRO_NAME;
+    else process.env.WSL_DISTRO_NAME = origDistro;
+  });
+
+  it('passes through when godotPath is not a .exe', () => {
+    expect(toWindowsAccessiblePath('/home/me/x.gd', '/usr/bin/godot')).toBe('/home/me/x.gd');
+  });
+
+  it('converts /mnt/<letter>/... to Windows drive form for Godot.exe', () => {
+    expect(toWindowsAccessiblePath('/mnt/c/Foo/bar.gd', 'C:/Godot/Godot.exe')).toBe(
+      'C:/Foo/bar.gd'
+    );
+  });
+
+  it('converts /home/... to WSL UNC form for Godot.exe', () => {
+    process.env.WSL_DISTRO_NAME = 'Ubuntu';
+    expect(toWindowsAccessiblePath('/home/me/script.gd', 'C:/Godot/Godot.exe')).toBe(
+      '\\\\wsl.localhost\\Ubuntu\\home\\me\\script.gd'
+    );
+  });
+
+  it('uses WSL_DISTRO_NAME from the environment when present', () => {
+    process.env.WSL_DISTRO_NAME = 'Debian';
+    expect(toWindowsAccessiblePath('/opt/tool', 'C:/Godot/Godot.exe')).toMatch(
+      /\\\\wsl\.localhost\\Debian\\opt\\tool/
+    );
+  });
+
+  it('defaults the distro to Ubuntu when the env var is unset', () => {
+    delete process.env.WSL_DISTRO_NAME;
+    expect(toWindowsAccessiblePath('/var/x', 'C:/Godot/Godot.exe')).toMatch(
+      /^\\\\wsl\.localhost\\Ubuntu\\var\\x$/
+    );
+  });
+
+  it('passes a Windows-native path through unchanged', () => {
+    expect(toWindowsAccessiblePath('C:/Foo/bar.gd', 'C:/Godot/Godot.exe')).toBe(
+      'C:/Foo/bar.gd'
+    );
+  });
+
+  it('is a no-op on non-linux platforms', () => {
+    setPlatform('win32');
+    expect(toWindowsAccessiblePath('/home/me/x.gd', 'C:/Godot/Godot.exe')).toBe(
+      '/home/me/x.gd'
+    );
+  });
+
+  it('returns the input unchanged when path or godotPath is empty', () => {
+    expect(toWindowsAccessiblePath('', 'C:/Godot/Godot.exe')).toBe('');
+    expect(toWindowsAccessiblePath('/home/me/x.gd', null)).toBe('/home/me/x.gd');
+  });
+});
+
+describe('parseGodotIni', () => {
+  it('parses a simple flat section', () => {
+    const out = parseGodotIni(
+      `[application]\n` +
+        `config/name="Game"\n` +
+        `run/main_scene="res://Main.tscn"\n`
+    );
+    expect(out.application).toEqual({
+      'config/name': '"Game"',
+      'run/main_scene': '"res://Main.tscn"',
+    });
+  });
+
+  it('parses multi-line input map actions without truncation', () => {
+    const content =
+      `[input]\n` +
+      `PaintGrass={\n` +
+      `"deadzone": 0.5,\n` +
+      `"events": [Object(InputEventKey,"keycode":71,"pressed":false)]\n` +
+      `}\n`;
+    const out = parseGodotIni(content);
+    expect(out.input).toBeDefined();
+    expect(out.input.PaintGrass).toContain('"deadzone": 0.5');
+    expect(out.input.PaintGrass).toContain('"events"');
+    expect(out.input.PaintGrass).toContain('"keycode":71');
+    expect(out.input.PaintGrass.trim().endsWith('}')).toBe(true);
+  });
+
+  it('parses multi-line array values', () => {
+    const content =
+      `[autoload]\n` +
+      `Globals=[\n` +
+      `"res://a.gd",\n` +
+      `"res://b.gd"\n` +
+      `]\n`;
+    const out = parseGodotIni(content);
+    expect(out.autoload.Globals).toContain('"res://a.gd"');
+    expect(out.autoload.Globals).toContain('"res://b.gd"');
+    expect(out.autoload.Globals.trim().endsWith(']')).toBe(true);
+  });
+
+  it('ignores braces inside string literals for depth tracking', () => {
+    const content =
+      `[input]\n` +
+      `evil={\n` +
+      `"comment": "has } inside",\n` +
+      `"closer": "[ not opener"\n` +
+      `}\n`;
+    const out = parseGodotIni(content);
+    expect(out.input.evil.trim().endsWith('}')).toBe(true);
+    expect(out.input.evil).toContain('"has } inside"');
+  });
+
+  it('skips comments and blank lines', () => {
+    const out = parseGodotIni(
+      `; comment\n` +
+        `\n` +
+        `[rendering]\n` +
+        `; another\n` +
+        `msaa_3d=2\n`
+    );
+    expect(out.rendering.msaa_3d).toBe('2');
+  });
+
+  it('handles multiple sections with mixed single and multi-line values', () => {
+    const content =
+      `[application]\n` +
+      `config/name="X"\n` +
+      `\n` +
+      `[input]\n` +
+      `jump={\n` +
+      `"events": []\n` +
+      `}\n` +
+      `left={"deadzone": 0.5}\n`;
+    const out = parseGodotIni(content);
+    expect(out.application['config/name']).toBe('"X"');
+    expect(out.input.jump).toContain('"events"');
+    expect(out.input.jump.trim().endsWith('}')).toBe(true);
+    expect(out.input.left).toBe('{"deadzone": 0.5}');
   });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeParameters,
   convertCamelToSnakeCase,
   validatePath,
+  validateProjectPath,
   createErrorResponse,
   isGodot44OrLater,
   toWslProjectPath,
@@ -183,6 +184,32 @@ describe('validatePath', () => {
   it('returns false for null/undefined', () => {
     expect(validatePath(null as any)).toBe(false);
     expect(validatePath(undefined as any)).toBe(false);
+  });
+});
+
+describe('validateProjectPath', () => {
+  const originalRoots = process.env.GODOT_MCP_PROJECT_ROOTS;
+
+  afterEach(() => {
+    if (originalRoots === undefined) delete process.env.GODOT_MCP_PROJECT_ROOTS;
+    else process.env.GODOT_MCP_PROJECT_ROOTS = originalRoots;
+  });
+
+  it('allows any valid project path when no project roots are configured', () => {
+    delete process.env.GODOT_MCP_PROJECT_ROOTS;
+    expect(validateProjectPath('/home/user/project')).toBe(true);
+  });
+
+  it('allows only configured absolute project roots when configured', () => {
+    process.env.GODOT_MCP_PROJECT_ROOTS = '/mnt/c/Code/SpaceportArchitect/SpaceportArchitect';
+    expect(validateProjectPath('/mnt/c/Code/SpaceportArchitect/SpaceportArchitect')).toBe(true);
+    expect(validateProjectPath('/mnt/c/Code/SpaceportArchitect/SpaceportArchitect/Bootstrap')).toBe(true);
+    expect(validateProjectPath('/mnt/c/Code/OtherProject')).toBe(false);
+  });
+
+  it('rejects relative project paths when project roots are configured', () => {
+    process.env.GODOT_MCP_PROJECT_ROOTS = '/mnt/c/Code/SpaceportArchitect/SpaceportArchitect';
+    expect(validateProjectPath('Bootstrap/Game.tscn')).toBe(false);
   });
 });
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -11,6 +11,7 @@ import {
   toNativeProjectPath,
   isWindowsGodotExe,
   projectGodotFile,
+  projectFilePath,
   toWindowsAccessiblePath,
   parseGodotIni,
 } from '../src/utils.js';
@@ -337,6 +338,26 @@ describe('projectGodotFile', () => {
   });
 });
 
+describe('projectFilePath', () => {
+  const origPlatform = process.platform;
+  const setPlatform = (p: NodeJS.Platform) => {
+    Object.defineProperty(process, 'platform', { value: p, configurable: true });
+  };
+  afterEach(() => setPlatform(origPlatform));
+
+  it('translates Windows-style paths on linux', () => {
+    setPlatform('linux');
+    expect(projectFilePath('C:/game', 'Dockerfile')).toBe('/mnt/c/game/Dockerfile');
+  });
+
+  it('passes linux-native paths through', () => {
+    setPlatform('linux');
+    expect(projectFilePath('/home/me/game', 'addons', 'x')).toBe(
+      '/home/me/game/addons/x'
+    );
+  });
+});
+
 describe('toWindowsAccessiblePath', () => {
   const origPlatform = process.platform;
   const origDistro = process.env.WSL_DISTRO_NAME;
@@ -398,6 +419,32 @@ describe('toWindowsAccessiblePath', () => {
   it('returns the input unchanged when path or godotPath is empty', () => {
     expect(toWindowsAccessiblePath('', 'C:/Godot/Godot.exe')).toBe('');
     expect(toWindowsAccessiblePath('/home/me/x.gd', null)).toBe('/home/me/x.gd');
+  });
+
+  it('passes an already-UNC path through unchanged', () => {
+    expect(
+      toWindowsAccessiblePath('\\\\wsl.localhost\\Ubuntu\\home\\me', 'C:/Godot/Godot.exe')
+    ).toBe('\\\\wsl.localhost\\Ubuntu\\home\\me');
+  });
+
+  it('passes a bare drive letter through unchanged', () => {
+    expect(toWindowsAccessiblePath('C:', 'C:/Godot/Godot.exe')).toBe('C:');
+  });
+
+  it('passes a drive-relative path through unchanged', () => {
+    expect(toWindowsAccessiblePath('C:project.godot', 'C:/Godot/Godot.exe')).toBe(
+      'C:project.godot'
+    );
+  });
+
+  it('handles /mnt/c with no subpath', () => {
+    expect(toWindowsAccessiblePath('/mnt/c', 'C:/Godot/Godot.exe')).toBe('C:/');
+  });
+
+  it('leaves relative linux-style paths alone', () => {
+    expect(toWindowsAccessiblePath('scripts/x.gd', 'C:/Godot/Godot.exe')).toBe(
+      'scripts/x.gd'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

  Four additions to the MCP server for mixed-language and cross-platform workflows:

  ### Tool filtering with category tags
  - `GODOT_MCP_CONFIG` JSON file and `GODOT_MCP_{ENABLED,DISABLED}_{TOOLS,TAGS}` env vars control which tools are exposed.
  - Disabled tools return MCP `MethodNotFound` and disappear from `tools/list`.
  - All 154 tools tagged by category (`2d`, `3d`, `audio`, `ui`, `physics`, `input`, `animation`, `networking`, `signal`, `shader`, `scene`, `script`, `runtime`, `headless`, `editor`, `project`, `file-io`, `rendering`, `navigation`, `gdscript-only`).
  - Empty/whitespace env vars treated as unset so a stray shell export can't wipe a JSON-configured list.

  ### C# script support
  - `create_script` emits Godot 4 C# templates when the target ends in `.cs`, with `override` detection for `_Ready`, `_Process`, `_PhysicsProcess`, `_Input`, `_UnhandledInput`, `_UnhandledKeyInput`, `_ShortcutInput`, `_GuiInput`, `_EnterTree`,
  `_ExitTree`, `_Notification`, `_IntegrateForces`, `_Get`, `_Set`, `_GetPropertyList`, `_Draw`. Snake_case method names normalize to the correct PascalCase; file-derived class names are PascalCased across all segments.
  - `attach_script` (headless) and `game_script` accept `.cs` via `scriptPath`.
  - `game_script get_source` reads on-disk source for `CSharpScript` via `FileAccess` (string-compared, works on non-mono builds).
  - Only `game_eval` stays GDScript-only — runtime inline C# would need a Roslyn scripting runtime.

  ### WSL + Windows Godot interop
  - Accept Windows-style project paths (`C:/…`, `C:\…`) on Linux; translate to `/mnt/c/…` for `fs` calls and back to a drive path or `\\wsl.localhost\<distro>\…` UNC for Godot.exe's `--path` and `--script` args.
  - `GODOT_PATH` and `config.godotPath` are trusted as-is; the old `existsSync` / `execFile --version` pre-validation fell through to autodetect on WSL interop failures and hid the real error.
  - Applied systematically: every `join(projectPath, …)`, `readdirSync`, `existsSync`, `mkdirSync`, and export `outputPath` routed through `projectFilePath` / `toWslProjectPath` / `toWindowsAccessiblePath`.

  ### Parser fixes
  - `get_uid` supports Godot 4.4+ inline `uid="uid://…"` headers in `.tscn` / `.tres` / `.gdshader(inc)` before falling back to the sidecar `.uid` file; loosened regex for future quoting variants.
  - TypeScript side parses the trailing JSON the GDScript emits and branches on `{exists, uid, message}` so the "run the editor once / use resave_resources" hint reaches the user instead of being swallowed by the engine banner.
  - `parseGodotIni` walks brace/bracket depth with cross-line string-state so multi-line input map actions and autoload arrays no longer truncate at the first line.

  ## Tests

  497 pass (from 316). New coverage for tool filtering, tag filtering, script templates (GDScript + C#, all lifecycles), WSL/Windows path translation, `parseGodotIni`, `toWindowsAccessiblePath` edge cases.

  ## Backwards compatibility

  No filter config means every tool remains enabled, matching prior behavior. Existing GDScript workflows are unchanged; C# support is purely additive.