### PR TITLE
Add .NET/C# project support and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![](https://img.shields.io/badge/TypeScript-3178C6?style=flat&logo=typescript&logoColor=white 'TypeScript')](https://www.typescriptlang.org/)
 [![](https://img.shields.io/badge/License-MIT-red.svg 'MIT License')](https://opensource.org/licenses/MIT)
 
-A comprehensive [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) server that gives AI assistants **full control** over the Godot game engine. **149 tools** spanning networking, 3D/2D rendering, UI controls, audio effects, animation trees, file I/O, runtime code execution, property inspection, scene manipulation, signal management, physics, project creation, and more.
+A comprehensive [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) server that gives AI assistants **full control** over the Godot game engine. **150 tools** spanning networking, 3D/2D rendering, UI controls, audio effects, animation trees, file I/O, runtime code execution, property inspection, scene manipulation, signal management, physics, project creation, and more.
 
 ## Acknowledgments
 
@@ -16,7 +16,7 @@ This project is built upon and extends [godot-mcp](https://github.com/Coding-Sol
 
 ## What's New (Improvements Over Original)
 
-The original godot-mcp provided 20 tools for basic project management and scene creation. This fork extends it to **149 tools** with the following major additions:
+The original godot-mcp provided 20 tools for basic project management and scene creation. This fork extends it to **150 tools** with the following major additions:
 
 ### Runtime Code Execution
 - **`game_eval`** - Execute arbitrary GDScript code in the running game with return values
@@ -75,7 +75,8 @@ The original godot-mcp provided 20 tools for basic project management and scene 
 - **`game_gamepad`** - Gamepad button and axis input events
 
 ### Project Creation & Configuration
-- **`create_project`** - Create a new Godot project from scratch
+- **`create_project`** - Create a new Godot project from scratch (supports `dotnet: true` for .NET projects)
+- **`create_csharp_script`** - Create a C# script file (requires .NET project)
 - **`manage_autoloads`** - Add, remove, or list autoloads
 - **`manage_input_map`** - Add, remove, or list input actions and key bindings
 - **`manage_export_presets`** - Create or modify export preset configuration
@@ -194,7 +195,7 @@ The original godot-mcp provided 20 tools for basic project management and scene 
 - **PackedArray serialization** - Proper JSON arrays instead of string fallback
 - **Graceful error handling** - Scene read fallback to raw .tscn text on missing dependencies
 
-## All 149 Tools
+## All 150 Tools
 
 ### Project Management (7 tools)
 | Tool | Description |
@@ -315,7 +316,7 @@ The original godot-mcp provided 20 tools for basic project management and scene 
 | `game_input_state` | Query pressed keys, mouse position, connected pads |
 | `game_input_action` | Manage runtime InputMap actions and strength |
 
-### Project Creation (4 tools)
+### Project Creation (5 tools)
 | Tool | Description |
 |------|-------------|
 | `create_project` | Create a new Godot project from scratch |
@@ -415,12 +416,19 @@ The original godot-mcp provided 20 tools for basic project management and scene 
 | `game_audio_bus_layout` | Create/remove/reorder audio buses and routing |
 | `game_audio_spatial` | Configure AudioStreamPlayer3D spatial properties |
 
+### .NET / C# Support (2 tools)
+| Tool | Description |
+|------|-------------|
+| `create_csharp_script` | Create a C# script file in a Godot .NET project |
+| `create_project` | Now supports `dotnet: true` for .NET project scaffolding |
+
 ### Editor & Project Tools (12 tools)
 | Tool | Description |
 |------|-------------|
 | `rename_file` | Rename or move a file within the project |
 | `manage_resource` | Read or modify .tres/.res resource files |
 | `create_script` | Create a GDScript file from a template |
+| `create_csharp_script` | Create a C# script file in a Godot .NET project |
 | `manage_scene_signals` | List/add/remove signal connections in .tscn files |
 | `manage_layers` | List/set named layer definitions in project |
 | `manage_plugins` | List/enable/disable editor plugins |
@@ -453,7 +461,8 @@ The original godot-mcp provided 20 tools for basic project management and scene 
 
 - [Godot Engine](https://godotengine.org/download) (4.x recommended, 4.4+ for UID features)
 - [Node.js](https://nodejs.org/) >= 18.0.0
-- An AI assistant that supports MCP (Claude Code, Cline, Cursor, etc.)
+- An AI assistant that supports MCP (Claude Code, Cline, Cursor, OpenCode, etc.)
+- (Optional) [.NET SDK](https://dotnet.microsoft.com/download) and Godot .NET for C# development
 
 ## Installation
 
@@ -501,6 +510,34 @@ Add to your Cline MCP settings (`cline_mcp_settings.json`):
 }
 ```
 
+### OpenCode
+
+Add to your project's `opencode.json` (or create one at the project root):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "godot": {
+      "type": "local",
+      "command": ["npx", "-y", "@tugcantopaloglu/godot-mcp"],
+      "enabled": true,
+      "environment": {
+        "GODOT_PATH": "/path/to/godot"
+      }
+    }
+  }
+}
+```
+
+For local development (cloned repo), use the build directly:
+
+```json
+{
+  "command": ["node", "/absolute/path/to/godot-mcp/build/index.js"]
+}
+```
+
 ### Cursor
 
 Create `.cursor/mcp.json` in your project:
@@ -525,6 +562,52 @@ To use the `game_*` runtime tools, your Godot project needs the MCP interaction 
 3. Add the script with the name `McpInteractionServer`
 
 The server listens on `127.0.0.1:9090` and accepts JSON commands over TCP when the game is running.
+
+## .NET / C# Support
+
+The server provides first-class support for Godot .NET (C#) projects.
+
+### Detecting .NET Projects
+
+The `get_project_info` tool automatically detects .NET projects by checking for `.csproj` files and returns an `isDotnet` field:
+
+```json
+{
+  "name": "MyGame",
+  "path": "/path/to/project",
+  "godotVersion": "4.3.stable",
+  "isDotnet": true,
+  "structure": { ... }
+}
+```
+
+### Creating a .NET Project
+
+Use `create_project` with the `dotnet: true` flag to scaffold a .NET Godot project:
+
+```
+Create a new Godot .NET project called "MyRpgGame" with dotnet: true
+```
+
+This generates:
+- `project.godot` with the `DotNet` feature flag
+- A `.csproj` file targeting `net8.0` with the `Godot.NET.Sdk/4.3.0`
+
+### Creating C# Scripts
+
+Use the `create_csharp_script` tool to create C# script files:
+
+```json
+{
+  "projectPath": "/path/to/project",
+  "scriptPath": "scripts/Player.cs",
+  "inherits": "CharacterBody3D",
+  "namespace": "MyRpgGame",
+  "methods": ["_Ready", "_Process", "_PhysicsProcess"]
+}
+```
+
+The tool validates that the project is a .NET project (has `.csproj`) before creating the script.
 
 ## Environment Variables
 
@@ -558,13 +641,15 @@ The project uses [Vitest](https://vitest.dev/) with 390 tests across 3 files:
 | File | Tests | What it covers |
 |------|-------|----------------|
 | `tests/utils.test.ts` | 31 | Parameter mappings, normalization, path validation, error responses, version detection |
-| `tests/tool-definitions.test.ts` | 157 | All 149 tools defined, schemas valid, names unique, descriptions < 80 chars |
-| `tests/handlers.test.ts` | 202 | Game command arg transforms, required-param validation, headless op path checks, source structure |
+| `tests/tool-definitions.test.ts` | 163 | All 150 tools defined, schemas valid, names unique, descriptions < 80 chars |
+| `tests/handlers.test.ts` | 226 | Game command arg transforms, required-param validation, headless op path checks, source structure |
+| `tests/dotnet.test.ts` | 27 | .NET detection, C# script template generation, handler validation, tool definitions |
+| `tests/server.test.ts` | 24 | GodotServer class integration tests with mocked fs/child_process/net |
 
 ```bash
-npm test          # run once
-npm run test:watch  # watch mode
-```
+npm test             # run once
+npm run test:watch   # watch mode
+npm run test:coverage  # with coverage (index.ts: 8%, utils.ts: 100%)
 
 ## Example Prompts
 
@@ -611,4 +696,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## Credits
 
 - **Original project**: [godot-mcp](https://github.com/Coding-Solo/godot-mcp) by [Solomon Elias (Coding-Solo)](https://github.com/Coding-Solo) - provided the foundational MCP server architecture, headless operations system, and TCP interaction framework
-- **Extended by**: [Tugcan Topaloglu](https://github.com/tugcantopaloglu) - extended to 149 tools covering networking, 3D/2D rendering, UI controls, audio effects, animation trees, file I/O, runtime code execution, node manipulation, signals, project creation, camera control, physics, and comprehensive type conversion
+- **Extended by**: [Tugcan Topaloglu](https://github.com/tugcantopaloglu) - extended to 150 tools covering networking, 3D/2D rendering, UI controls, audio effects, animation trees, file I/O, runtime code execution, node manipulation, signals, project creation, camera control, physics, and comprehensive type conversion

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "godot-mcp": {
+      "type": "local",
+      "command": ["npx", "-y", "@tugcantopaloglu/godot-mcp"],
+      "enabled": true,
+      "environment": {
+        "GODOT_PATH": "{env:GODOT_PATH}"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@modelcontextprotocol/sdk": "1.26.0",
         "axios": "^1.13.5",
         "fs-extra": "^11.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "ai",
     "claude",
     "cline",
+    "opencode",
     "game-engine",
     "gdscript",
     "runtime",
@@ -40,7 +41,8 @@
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.26.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,10 @@ import {
   validatePath,
   createErrorResponse,
   isGodot44OrLater,
+  generateCsharpScriptSource,
+  generateCsprojContent,
+  generateGodotProjectFeatures,
+  getGodotBinaryCandidates,
   type OperationParams,
 } from './utils.js';
 
@@ -246,35 +250,11 @@ class GodotServer {
     const osPlatform = process.platform;
     this.logDebug(`Auto-detecting Godot path for platform: ${osPlatform}`);
 
-    const possiblePaths: string[] = [
-      'godot', // Check if 'godot' is in PATH first
-    ];
-
-    // Add platform-specific paths
-    if (osPlatform === 'darwin') {
-      possiblePaths.push(
-        '/Applications/Godot.app/Contents/MacOS/Godot',
-        '/Applications/Godot_4.app/Contents/MacOS/Godot',
-        `${process.env.HOME}/Applications/Godot.app/Contents/MacOS/Godot`,
-        `${process.env.HOME}/Applications/Godot_4.app/Contents/MacOS/Godot`,
-        `${process.env.HOME}/Library/Application Support/Steam/steamapps/common/Godot Engine/Godot.app/Contents/MacOS/Godot`
-      );
-    } else if (osPlatform === 'win32') {
-      possiblePaths.push(
-        'C:\\Program Files\\Godot\\Godot.exe',
-        'C:\\Program Files (x86)\\Godot\\Godot.exe',
-        'C:\\Program Files\\Godot_4\\Godot.exe',
-        'C:\\Program Files (x86)\\Godot_4\\Godot.exe',
-        `${process.env.USERPROFILE}\\Godot\\Godot.exe`
-      );
-    } else if (osPlatform === 'linux') {
-      possiblePaths.push(
-        '/usr/bin/godot',
-        '/usr/local/bin/godot',
-        '/snap/bin/godot',
-        `${process.env.HOME}/.local/bin/godot`
-      );
-    }
+    const possiblePaths = getGodotBinaryCandidates(
+      osPlatform,
+      process.env.HOME,
+      process.env.USERPROFILE,
+    );
 
     // Try each possible path
     for (const path of possiblePaths) {
@@ -762,6 +742,18 @@ class GodotServer {
     }
 
     return projects;
+  }
+
+  /**
+   * Check if a Godot project is a .NET (C#) project by looking for .csproj files
+   */
+  private isDotnetProject(projectPath: string): boolean {
+    try {
+      const entries = readdirSync(projectPath);
+      return entries.some(e => e.endsWith('.csproj'));
+    } catch {
+      return false;
+    }
   }
 
   /**
@@ -1703,19 +1695,20 @@ class GodotServer {
         },
         // Project management tools
         {
-          name: 'create_project',
-          description: 'Create a new Godot project from scratch',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              projectPath: { type: 'string', description: 'Directory where the project will be created' },
-              projectName: { type: 'string', description: 'Name of the project' },
+            name: 'create_project',
+            description: 'Create a new Godot project from scratch',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                projectPath: { type: 'string', description: 'Directory where the project will be created' },
+                projectName: { type: 'string', description: 'Name of the project' },
+                dotnet: { type: 'boolean', description: 'Create .NET (C#) project with .csproj and DotNet feature flag. Default: false' },
+              },
+              required: ['projectPath', 'projectName'],
             },
-            required: ['projectPath', 'projectName'],
           },
-        },
-        {
-          name: 'manage_autoloads',
+          {
+            name: 'manage_autoloads',
           description: 'Add, remove, or list autoloads in a Godot project',
           inputSchema: {
             type: 'object',
@@ -2814,6 +2807,41 @@ class GodotServer {
           },
         },
         {
+          name: 'create_csharp_script',
+          description: 'Create a C# script file in a Godot .NET project',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: {
+                type: 'string',
+                description: 'Godot project path',
+              },
+              scriptPath: {
+                type: 'string',
+                description: 'Script file path (relative to project, e.g. "scripts/Player.cs")',
+              },
+              namespace: {
+                type: 'string',
+                description: 'Optional namespace. Defaults to project name',
+              },
+              inherits: {
+                type: 'string',
+                description: 'Base class to inherit from. Default: Node',
+              },
+              methods: {
+                type: 'array',
+                items: { type: 'string' },
+                description: 'Optional method stubs to include',
+              },
+              source: {
+                type: 'string',
+                description: 'Full source code (overrides template)',
+              },
+            },
+            required: ['projectPath', 'scriptPath'],
+          },
+        },
+        {
           name: 'manage_scene_signals',
           description: 'List/add/remove signal connections in .tscn files',
           inputSchema: {
@@ -3471,6 +3499,8 @@ class GodotServer {
           return await this.handleManageResource(request.params.arguments);
         case 'create_script':
           return await this.handleCreateScript(request.params.arguments);
+        case 'create_csharp_script':
+          return await this.handleCreateCsharpScript(request.params.arguments);
         case 'manage_scene_signals':
           return await this.handleManageSceneSignals(request.params.arguments);
         case 'manage_layers':
@@ -3964,6 +3994,7 @@ class GodotServer {
   
       // Extract project name from project.godot file
       let projectName = basename(args.projectPath);
+      const isDotnet = this.isDotnetProject(args.projectPath);
       try {
         const projectFileContent = readFileSync(projectFile, 'utf8');
         const configNameMatch = projectFileContent.match(/config\/name="([^"]+)"/);
@@ -3975,7 +4006,7 @@ class GodotServer {
         this.logDebug(`Error reading project file: ${error}`);
         // Continue with default project name if extraction fails
       }
-  
+
       return {
         content: [
           {
@@ -3985,6 +4016,7 @@ class GodotServer {
                 name: projectName,
                 path: args.projectPath,
                 godotVersion: stdout.trim(),
+                isDotnet,
                 structure: projectStructure,
               },
               null,
@@ -5081,9 +5113,19 @@ class GodotServer {
       const projectFile = join(args.projectPath, 'project.godot');
       if (existsSync(projectFile))
         return createErrorResponse('A project.godot already exists at this path.');
-      const content = `; Engine configuration file.\n; Generated by Godot MCP.\n\nconfig_version=5\n\n[application]\n\nconfig/name="${args.projectName}"\nconfig/features=PackedStringArray("4.3")\n`;
+
+      const isDotnet = args.dotnet === true;
+      const features = generateGodotProjectFeatures(isDotnet);
+      const content = `; Engine configuration file.\n; Generated by Godot MCP.\n\nconfig_version=5\n\n[application]\n\nconfig/name="${args.projectName}"\nconfig/features=${features}\n`;
       writeFileSync(projectFile, content, 'utf8');
-      return { content: [{ type: 'text', text: `Project "${args.projectName}" created at ${args.projectPath}` }] };
+
+      if (isDotnet) {
+        const csprojContent = generateCsprojContent(args.projectName);
+        const safeName = args.projectName.replace(/[^a-zA-Z0-9_]/g, '_');
+        writeFileSync(join(args.projectPath, `${safeName}.csproj`), csprojContent, 'utf8');
+      }
+
+      return { content: [{ type: 'text', text: `Project "${args.projectName}" created at ${args.projectPath}${isDotnet ? ' (Godot .NET)' : ''}` }] };
     } catch (error: any) {
       return createErrorResponse(`Failed to create project: ${error?.message || 'Unknown error'}`);
     }
@@ -6112,6 +6154,36 @@ class GodotServer {
     }
   }
 
+  private async handleCreateCsharpScript(args: any) {
+    args = normalizeParameters(args || {});
+    if (!args.projectPath || !args.scriptPath) return createErrorResponse('projectPath and scriptPath are required.');
+    if (!validatePath(args.projectPath) || !validatePath(args.scriptPath)) return createErrorResponse('Invalid path.');
+    const projectFile = join(args.projectPath, 'project.godot');
+    if (!existsSync(projectFile)) return createErrorResponse(`Not a valid Godot project: ${args.projectPath}`);
+    if (!this.isDotnetProject(args.projectPath)) return createErrorResponse('Not a Godot .NET project. Create a .csproj file first or use create_project with dotnet: true.');
+    try {
+      const fullPath = join(args.projectPath, args.scriptPath);
+      const dir = dirname(fullPath);
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+      let source = args.source;
+      if (!source) {
+        const ns = args.namespace || basename(args.projectPath).replace(/[^a-zA-Z0-9_]/g, '_');
+        const inherits = args.inherits || 'Node';
+        const className = basename(args.scriptPath, '.cs');
+        source = generateCsharpScriptSource({
+          namespace: ns,
+          inherits,
+          className,
+          methods: args.methods,
+        });
+      }
+      writeFileSync(fullPath, source, 'utf8');
+      return { content: [{ type: 'text', text: `C# script created at ${args.scriptPath}` }] };
+    } catch (error: any) {
+      return createErrorResponse(`create_csharp_script failed: ${error?.message || 'Unknown error'}`);
+    }
+  }
+
   private async handleManageSceneSignals(args: any) {
     args = normalizeParameters(args || {});
     if (!args.projectPath || !args.scenePath || !args.action) return createErrorResponse('projectPath, scenePath, and action are required.');
@@ -6679,10 +6751,14 @@ class GodotServer {
   }
 }
 
-// Create and run the server
-const server = new GodotServer();
-server.run().catch((error: unknown) => {
-  const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-  console.error('Failed to run server:', errorMessage);
-  process.exit(1);
-});
+// Prevent auto-start during vitest so the class can be imported for testing
+if (!process.env.VITEST) {
+  const server = new GodotServer();
+  server.run().catch((error: unknown) => {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('Failed to run server:', errorMessage);
+    process.exit(1);
+  });
+}
+
+export { GodotServer };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -232,3 +232,100 @@ export function isGodot44OrLater(version: string): boolean {
   }
   return false;
 }
+
+export interface CsharpScriptOptions {
+  namespace: string;
+  inherits: string;
+  className: string;
+  methods?: string[];
+}
+
+export function generateCsharpScriptSource(opts: CsharpScriptOptions): string {
+  const lines: string[] = [
+    'using Godot;',
+    'using System;',
+    '',
+    `namespace ${opts.namespace};`,
+    '',
+    `public partial class ${opts.className} : ${opts.inherits}`,
+    '{',
+  ];
+  const methods = opts.methods && opts.methods.length > 0 ? opts.methods : ['_Ready'];
+  for (const m of methods) {
+    lines.push(`    public override void ${m}()`);
+    lines.push('    {');
+    lines.push('        // TODO: Implement');
+    lines.push('    }');
+    lines.push('');
+  }
+  lines.push('}');
+  return lines.join('\n') + '\n';
+}
+
+export function generateCsprojContent(projectName: string): string {
+  const safeName = projectName.replace(/[^a-zA-Z0-9_]/g, '_');
+  return `<Project Sdk="Godot.NET.Sdk/4.3.0">\n  <PropertyGroup>\n    <TargetFramework>net8.0</TargetFramework>\n    <RootNamespace>${safeName}</RootNamespace>\n    <Nullable>enable</Nullable>\n  </PropertyGroup>\n</Project>\n`;
+}
+
+export function generateGodotProjectFeatures(isDotnet: boolean): string {
+  return isDotnet ? 'PackedStringArray("4.3", "DotNet")' : 'PackedStringArray("4.3")';
+}
+
+export function getGodotBinaryCandidates(
+  platform: string,
+  homeDir?: string,
+  userProfile?: string,
+): string[] {
+  const paths: string[] = ['godot'];
+  if (platform === 'darwin') {
+    paths.push(
+      '/Applications/Godot.app/Contents/MacOS/Godot',
+      '/Applications/Godot_4.app/Contents/MacOS/Godot',
+      '/Applications/Godot_mono.app/Contents/MacOS/Godot',
+      '/Applications/Godot_4_mono.app/Contents/MacOS/Godot',
+    );
+    if (homeDir) {
+      paths.push(
+        `${homeDir}/Applications/Godot.app/Contents/MacOS/Godot`,
+        `${homeDir}/Applications/Godot_4.app/Contents/MacOS/Godot`,
+        `${homeDir}/Applications/Godot_mono.app/Contents/MacOS/Godot`,
+        `${homeDir}/Applications/Godot_4_mono.app/Contents/MacOS/Godot`,
+        `${homeDir}/Library/Application Support/Steam/steamapps/common/Godot Engine/Godot.app/Contents/MacOS/Godot`,
+      );
+    }
+  } else if (platform === 'win32') {
+    paths.push(
+      'C:\\Program Files\\Godot\\Godot.exe',
+      'C:\\Program Files\\Godot\\Godot_mono.exe',
+      'C:\\Program Files (x86)\\Godot\\Godot.exe',
+      'C:\\Program Files (x86)\\Godot\\Godot_mono.exe',
+      'C:\\Program Files\\Godot_4\\Godot.exe',
+      'C:\\Program Files\\Godot_4\\Godot_mono.exe',
+      'C:\\Program Files (x86)\\Godot_4\\Godot.exe',
+      'C:\\Program Files (x86)\\Godot_4\\Godot_mono.exe',
+      'C:\\Program Files\\Godot_mono\\Godot.exe',
+      'C:\\Program Files\\Godot_4_mono\\Godot.exe',
+    );
+    if (userProfile) {
+      paths.push(
+        `${userProfile}\\Godot\\Godot.exe`,
+        `${userProfile}\\Godot\\Godot_mono.exe`,
+      );
+    }
+  } else if (platform === 'linux') {
+    paths.push(
+      '/usr/bin/godot',
+      '/usr/bin/godot-mono',
+      '/usr/local/bin/godot',
+      '/usr/local/bin/godot-mono',
+      '/snap/bin/godot',
+    );
+    if (homeDir) {
+      paths.push(
+        `${homeDir}/.local/bin/godot`,
+        `${homeDir}/.local/bin/godot-mono`,
+      );
+    }
+  }
+  return paths;
+}

--- a/tests/dotnet.test.ts
+++ b/tests/dotnet.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import {
+  generateCsharpScriptSource,
+  generateCsprojContent,
+  generateGodotProjectFeatures,
+  getGodotBinaryCandidates,
+  normalizeParameters,
+} from '../src/utils.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const sourceCode = readFileSync(join(__dirname, '..', 'src', 'index.ts'), 'utf8');
+const utilsCode = readFileSync(join(__dirname, '..', 'src', 'utils.ts'), 'utf8');
+
+describe('generateCsharpScriptSource', () => {
+  it('generates a minimal C# script with default _Ready method', () => {
+    const result = generateCsharpScriptSource({
+      namespace: 'MyGame',
+      inherits: 'Node',
+      className: 'Player',
+    });
+    expect(result).toContain('using Godot;');
+    expect(result).toContain('using System;');
+    expect(result).toContain('namespace MyGame;');
+    expect(result).toContain('public partial class Player : Node');
+    expect(result).toContain('public override void _Ready()');
+    expect(result).toContain('// TODO: Implement');
+    expect(result).toContain('}');
+  });
+
+  it('generates script with custom methods', () => {
+    const result = generateCsharpScriptSource({
+      namespace: 'MyRpg',
+      inherits: 'CharacterBody3D',
+      className: 'Hero',
+      methods: ['_Ready', '_Process', '_PhysicsProcess'],
+    });
+    expect(result).toContain('namespace MyRpg;');
+    expect(result).toContain('public partial class Hero : CharacterBody3D');
+    expect(result).toContain('public override void _Ready()');
+    expect(result).toContain('public override void _Process()');
+    expect(result).toContain('public override void _PhysicsProcess()');
+  });
+
+  it('generates script with a single custom method (no default _Ready)', () => {
+    const result = generateCsharpScriptSource({
+      namespace: 'Game',
+      inherits: 'Control',
+      className: 'Hud',
+      methods: ['_EnterTree'],
+    });
+    expect(result).toContain('public override void _EnterTree()');
+    expect(result).not.toContain('public override void _Ready()');
+  });
+
+  it('handles empty methods array by defaulting to _Ready', () => {
+    const result = generateCsharpScriptSource({
+      namespace: 'Test',
+      inherits: 'Node',
+      className: 'TestScript',
+      methods: [],
+    });
+    expect(result).toContain('public override void _Ready()');
+  });
+
+  it('handles undefined methods by defaulting to _Ready', () => {
+    const result = generateCsharpScriptSource({
+      namespace: 'Test',
+      inherits: 'Node',
+      className: 'TestScript',
+    });
+    expect(result).toContain('public override void _Ready()');
+  });
+
+  it('each method has braces and TODO comment', () => {
+    const result = generateCsharpScriptSource({
+      namespace: 'Ns',
+      inherits: 'Node',
+      className: 'C',
+      methods: ['A', 'B'],
+    });
+    const methodCount = (result.match(/public override void/g) || []).length;
+    expect(methodCount).toBe(2);
+    expect(result).toContain('{');
+    expect(result).toContain('// TODO: Implement');
+  });
+
+  it('ends with a newline and closing brace', () => {
+    const result = generateCsharpScriptSource({
+      namespace: 'Ns',
+      inherits: 'Node',
+      className: 'C',
+    });
+    expect(result.endsWith('}\n')).toBe(true);
+  });
+});
+
+describe('isDotnetProject', () => {
+  it('exists in source', () => {
+    expect(sourceCode).toContain('isDotnetProject');
+  });
+
+  it('reads directory entries ending with .csproj', () => {
+    expect(sourceCode).toContain('readdirSync');
+    expect(sourceCode).toContain('.csproj');
+  });
+
+  it('returns false on error', () => {
+    // The catch block returns false
+    expect(sourceCode).toContain('catch');
+    expect(sourceCode).toContain('return false');
+  });
+});
+
+describe('handleCreateCsharpScript', () => {
+  it('exists in source as a handler method', () => {
+    expect(sourceCode).toContain('handleCreateCsharpScript');
+  });
+
+  it('validates projectPath and scriptPath are required', () => {
+    const args = normalizeParameters({ projectPath: '/game' });
+    expect(!args.projectPath || !args.scriptPath).toBe(true);
+  });
+
+  it('checks for project.godot before creating', () => {
+    expect(sourceCode).toContain("project.godot");
+    expect(sourceCode).toContain("Not a valid Godot project");
+  });
+
+  it('checks for .csproj (isDotnetProject) before creating', () => {
+    expect(sourceCode).toContain('isDotnetProject');
+    expect(sourceCode).toContain('Not a Godot .NET project');
+  });
+
+  it('falls back to default namespace from projectPath basename', () => {
+    expect(sourceCode).toContain('basename(args.projectPath)');
+  });
+
+  it('falls back to Node as default inherits', () => {
+    expect(sourceCode).toContain("inherits || 'Node'");
+  });
+});
+
+describe('handleCreateProject dotnet support', () => {
+  it('has dotnet property in schema definition', () => {
+    const createProjectBlock = sourceCode.substring(
+      sourceCode.indexOf("name: 'create_project'"),
+      sourceCode.indexOf("name: 'manage_autoloads'"),
+    );
+    expect(createProjectBlock).toContain('dotnet');
+  });
+
+  it('checks args.dotnet === true for .NET project creation', () => {
+    expect(sourceCode).toContain("args.dotnet === true");
+  });
+
+  it('generates .csproj file with Godot.NET.Sdk', () => {
+    expect(utilsCode).toContain('Godot.NET.Sdk');
+    expect(utilsCode).toContain('TargetFramework');
+    expect(utilsCode).toContain('net8.0');
+  });
+
+  it('includes DotNet in features when dotnet is true', () => {
+    expect(sourceCode).toContain('DotNet');
+  });
+
+  it('appends (Godot .NET) suffix in response text', () => {
+    expect(sourceCode).toContain("' (Godot .NET)'");
+  });
+});
+
+describe('get_project_info isDotnet field', () => {
+  it('calls isDotnetProject in get_project_info', () => {
+    expect(sourceCode).toContain('handleGetProjectInfo');
+    expect(sourceCode).toContain('isDotnetProject');
+  });
+
+  it('includes isDotnet in response', () => {
+    expect(sourceCode).toContain('isDotnet');
+  });
+});
+
+describe('create_csharp_script tool definition', () => {
+  it('defines create_csharp_script tool name', () => {
+    expect(sourceCode).toContain("name: 'create_csharp_script'");
+  });
+
+  it('has required projectPath and scriptPath properties', () => {
+    const toolBlock = sourceCode.substring(
+      sourceCode.indexOf("name: 'create_csharp_script'"),
+    );
+    // Find the required array within this tool block (stops before next tool)
+    const requiredEnd = toolBlock.indexOf('required:');
+    const propsEnd = requiredEnd !== -1 ? requiredEnd : toolBlock.length;
+    const propsBlock = toolBlock.substring(0, propsEnd);
+    expect(propsBlock).toContain('projectPath');
+    expect(propsBlock).toContain('scriptPath');
+  });
+
+  it('has optional properties inherits, namespace, methods, source', () => {
+    const toolBlock = sourceCode.substring(
+      sourceCode.indexOf("name: 'create_csharp_script'"),
+      sourceCode.indexOf("name: 'manage_scene_signals'"),
+    );
+    expect(toolBlock).toContain('inherits');
+    expect(toolBlock).toContain('namespace');
+    expect(toolBlock).toContain('methods');
+    expect(toolBlock).toContain('source');
+  });
+});
+
+describe('generateCsharpScriptSource in utils.ts', () => {
+  it('is exported from utils.ts', () => {
+    expect(utilsCode).toContain('export function generateCsharpScriptSource');
+  });
+});
+
+describe('generateCsprojContent', () => {
+  it('generates .csproj with Godot.NET.Sdk and net8.0', () => {
+    const result = generateCsprojContent('MyGame');
+    expect(result).toContain('<Project Sdk="Godot.NET.Sdk/4.3.0">');
+    expect(result).toContain('<TargetFramework>net8.0</TargetFramework>');
+    expect(result).toContain('<Nullable>enable</Nullable>');
+  });
+
+  it('sanitizes project name for RootNamespace', () => {
+    const result = generateCsprojContent('My Cool Game!');
+    expect(result).toContain('<RootNamespace>My_Cool_Game_</RootNamespace>');
+  });
+
+  it('handles already-safe names', () => {
+    const result = generateCsprojContent('GameName');
+    expect(result).toContain('<RootNamespace>GameName</RootNamespace>');
+  });
+
+  it('starts with Project Sdk and ends with Project tag', () => {
+    const result = generateCsprojContent('Test');
+    expect(result.trim()).toMatch(/^<Project /);
+    expect(result.trim()).toMatch(/<\/Project>$/);
+  });
+});
+
+describe('generateGodotProjectFeatures', () => {
+  it('returns DotNet features when isDotnet is true', () => {
+    const result = generateGodotProjectFeatures(true);
+    expect(result).toBe('PackedStringArray("4.3", "DotNet")');
+  });
+
+  it('returns standard features when isDotnet is false', () => {
+    const result = generateGodotProjectFeatures(false);
+    expect(result).toBe('PackedStringArray("4.3")');
+  });
+});
+
+describe('getGodotBinaryCandidates', () => {
+  it('always includes godot as first candidate', () => {
+    const result = getGodotBinaryCandidates('darwin');
+    expect(result[0]).toBe('godot');
+  });
+
+  it('returns darwin paths with mono variants', () => {
+    const result = getGodotBinaryCandidates('darwin', '/Users/test');
+    expect(result).toContain('/Applications/Godot.app/Contents/MacOS/Godot');
+    expect(result).toContain('/Applications/Godot_mono.app/Contents/MacOS/Godot');
+    expect(result).toContain('/Applications/Godot_4_mono.app/Contents/MacOS/Godot');
+  });
+
+  it('returns darwin home-relative paths when homeDir is provided', () => {
+    const result = getGodotBinaryCandidates('darwin', '/Users/test');
+    expect(result).toContain('/Users/test/Applications/Godot.app/Contents/MacOS/Godot');
+    expect(result).toContain('/Users/test/Applications/Godot_mono.app/Contents/MacOS/Godot');
+  });
+
+  it('returns darwin steam path when homeDir is provided', () => {
+    const result = getGodotBinaryCandidates('darwin', '/Users/test');
+    expect(result).toContain('/Users/test/Library/Application Support/Steam/steamapps/common/Godot Engine/Godot.app/Contents/MacOS/Godot');
+  });
+
+  it('does not include home-relative paths when homeDir is not provided', () => {
+    const result = getGodotBinaryCandidates('darwin');
+    expect(result).not.toContain('/Users');
+    expect(result).not.toContain('/Library');
+  });
+
+  it('returns win32 paths with mono variants', () => {
+    const result = getGodotBinaryCandidates('win32');
+    expect(result).toContain('C:\\Program Files\\Godot\\Godot.exe');
+    expect(result).toContain('C:\\Program Files\\Godot\\Godot_mono.exe');
+    expect(result).toContain('C:\\Program Files\\Godot_4_mono\\Godot.exe');
+  });
+
+  it('returns win32 user-specific paths when userProfile is provided', () => {
+    const result = getGodotBinaryCandidates('win32', undefined, 'C:\\Users\\test');
+    expect(result).toContain('C:\\Users\\test\\Godot\\Godot.exe');
+    expect(result).toContain('C:\\Users\\test\\Godot\\Godot_mono.exe');
+  });
+
+  it('does not include user-specific paths when userProfile is not provided', () => {
+    const result = getGodotBinaryCandidates('win32');
+    expect(result.filter(p => p.includes('Users'))).toHaveLength(0);
+  });
+
+  it('returns linux paths with mono variants', () => {
+    const result = getGodotBinaryCandidates('linux');
+    expect(result).toContain('/usr/bin/godot');
+    expect(result).toContain('/usr/bin/godot-mono');
+    expect(result).toContain('/usr/local/bin/godot-mono');
+  });
+
+  it('returns linux home-relative paths when homeDir is provided', () => {
+    const result = getGodotBinaryCandidates('linux', '/home/test');
+    expect(result).toContain('/home/test/.local/bin/godot');
+    expect(result).toContain('/home/test/.local/bin/godot-mono');
+  });
+
+  it('does not include home-relative paths on linux when no homeDir', () => {
+    const result = getGodotBinaryCandidates('linux');
+    expect(result.filter(p => p.includes('/home/'))).toHaveLength(0);
+  });
+
+  it('returns only godot for unknown platforms', () => {
+    const result = getGodotBinaryCandidates('android');
+    expect(result).toEqual(['godot']);
+  });
+});

--- a/tests/dotnet.test.ts
+++ b/tests/dotnet.test.ts
@@ -7,7 +7,6 @@ import {
   generateCsprojContent,
   generateGodotProjectFeatures,
   getGodotBinaryCandidates,
-  normalizeParameters,
 } from '../src/utils.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -94,91 +93,6 @@ describe('generateCsharpScriptSource', () => {
       className: 'C',
     });
     expect(result.endsWith('}\n')).toBe(true);
-  });
-});
-
-describe('isDotnetProject', () => {
-  it('exists in source', () => {
-    expect(sourceCode).toContain('isDotnetProject');
-  });
-
-  it('reads directory entries ending with .csproj', () => {
-    expect(sourceCode).toContain('readdirSync');
-    expect(sourceCode).toContain('.csproj');
-  });
-
-  it('returns false on error', () => {
-    // The catch block returns false
-    expect(sourceCode).toContain('catch');
-    expect(sourceCode).toContain('return false');
-  });
-});
-
-describe('handleCreateCsharpScript', () => {
-  it('exists in source as a handler method', () => {
-    expect(sourceCode).toContain('handleCreateCsharpScript');
-  });
-
-  it('validates projectPath and scriptPath are required', () => {
-    const args = normalizeParameters({ projectPath: '/game' });
-    expect(!args.projectPath || !args.scriptPath).toBe(true);
-  });
-
-  it('checks for project.godot before creating', () => {
-    expect(sourceCode).toContain("project.godot");
-    expect(sourceCode).toContain("Not a valid Godot project");
-  });
-
-  it('checks for .csproj (isDotnetProject) before creating', () => {
-    expect(sourceCode).toContain('isDotnetProject');
-    expect(sourceCode).toContain('Not a Godot .NET project');
-  });
-
-  it('falls back to default namespace from projectPath basename', () => {
-    expect(sourceCode).toContain('basename(args.projectPath)');
-  });
-
-  it('falls back to Node as default inherits', () => {
-    expect(sourceCode).toContain("inherits || 'Node'");
-  });
-});
-
-describe('handleCreateProject dotnet support', () => {
-  it('has dotnet property in schema definition', () => {
-    const createProjectBlock = sourceCode.substring(
-      sourceCode.indexOf("name: 'create_project'"),
-      sourceCode.indexOf("name: 'manage_autoloads'"),
-    );
-    expect(createProjectBlock).toContain('dotnet');
-  });
-
-  it('checks args.dotnet === true for .NET project creation', () => {
-    expect(sourceCode).toContain("args.dotnet === true");
-  });
-
-  it('generates .csproj file with Godot.NET.Sdk', () => {
-    expect(utilsCode).toContain('Godot.NET.Sdk');
-    expect(utilsCode).toContain('TargetFramework');
-    expect(utilsCode).toContain('net8.0');
-  });
-
-  it('includes DotNet in features when dotnet is true', () => {
-    expect(sourceCode).toContain('DotNet');
-  });
-
-  it('appends (Godot .NET) suffix in response text', () => {
-    expect(sourceCode).toContain("' (Godot .NET)'");
-  });
-});
-
-describe('get_project_info isDotnet field', () => {
-  it('calls isDotnetProject in get_project_info', () => {
-    expect(sourceCode).toContain('handleGetProjectInfo');
-    expect(sourceCode).toContain('isDotnetProject');
-  });
-
-  it('includes isDotnet in response', () => {
-    expect(sourceCode).toContain('isDotnet');
   });
 });
 

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -744,6 +744,11 @@ describe('Handler required-parameter validation', () => {
     expect(!args.projectPath || !args.projectName).toBe(true);
   });
 
+  it('create_csharp_script requires projectPath and scriptPath', () => {
+    const args = normalizeParameters({ projectPath: '/game' });
+    expect(!args.projectPath || !args.scriptPath).toBe(true);
+  });
+
   it('manage_autoloads requires projectPath and action', () => {
     const args = normalizeParameters({ projectPath: '/game' });
     expect(!args.projectPath || !args.action).toBe(true);
@@ -998,7 +1003,8 @@ describe('Handler source structure', () => {
 
   it('all project management handlers exist', () => {
     const pmHandlers = [
-      'handleCreateProject', 'handleManageAutoloads',
+      'handleCreateProject', 'handleCreateCsharpScript',
+      'handleManageAutoloads',
       'handleManageInputMap', 'handleManageExportPresets',
     ];
     for (const h of pmHandlers) {
@@ -1932,8 +1938,8 @@ describe('Tool dispatch switch statement', () => {
   it('every case returns await this.handle*', () => {
     const caseRegex = /case '(\w+)':\s*\n\s*return await this\.handle/g;
     const matches = [...sourceCode.matchAll(caseRegex)];
-    // Should match all 154 tools
-    expect(matches.length).toBe(154);
+    // Should match all 155 tools
+    expect(matches.length).toBe(155);
   });
 
   it('no case falls through without return', () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -261,42 +261,26 @@ describe('GodotServer', () => {
       expect(result.content[0].text).toContain('Not a valid Godot project');
     });
 
-    it('reads project info and includes isDotnet', async () => {
+    it.each`
+      scenario            | projectName  | featuresLine                                                                       | direntName           | expectedIsDotnet
+      ${'with .NET'}      | ${'TestGame'} | ${'config/features=PackedStringArray("4.3", "DotNet")\n'}                          | ${'TestGame.csproj'} | ${true}
+      ${'without .NET'}   | ${'MyGame'}   | ${''}                                                                              | ${'Main.gd'}         | ${false}
+    `('reads project info $scenario', async ({ projectName, featuresLine, direntName, expectedIsDotnet }) => {
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockReturnValue(`
 [application]
-config/name="TestGame"
-config/features=PackedStringArray("4.3", "DotNet")
-      `);
-      // getProjectStructureAsync (Dirent-like) called first, then isDotnetProject (strings)
+config/name="${projectName}"
+${featuresLine}      `);
       mockReaddirSync
         .mockReturnValueOnce([
-          { name: 'TestGame.csproj', isDirectory: () => false, isFile: () => true },
+          { name: direntName, isDirectory: () => false, isFile: () => true },
         ])
-        .mockReturnValueOnce(['TestGame.csproj']);
+        .mockReturnValueOnce([direntName]);
       const server = new (GodotServer as any)();
       const result = await server.handleGetProjectInfo({ projectPath: '/fake' });
       const json = JSON.parse(result.content[0].text);
-      expect(json.name).toBe('TestGame');
-      expect(json.isDotnet).toBe(true);
-    });
-
-    it('reads project info without .NET', async () => {
-      mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue(`
-[application]
-config/name="MyGame"
-      `);
-      mockReaddirSync
-        .mockReturnValueOnce([
-          { name: 'Main.gd', isDirectory: () => false, isFile: () => true },
-        ])
-        .mockReturnValueOnce(['Main.gd']);
-      const server = new (GodotServer as any)();
-      const result = await server.handleGetProjectInfo({ projectPath: '/fake' });
-      const json = JSON.parse(result.content[0].text);
-      expect(json.name).toBe('MyGame');
-      expect(json.isDotnet).toBe(false);
+      expect(json.name).toBe(projectName);
+      expect(json.isDotnet).toBe(expectedIsDotnet);
     });
   });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -189,7 +189,7 @@ describe('GodotServer', () => {
     it('creates a regular project successfully', async () => {
       const server = new (GodotServer as any)();
       const result = await server.handleCreateProject({
-        projectPath: '/tmp/test-project',
+        projectPath: '/safe/test-project',
         projectName: 'TestGame',
       });
       const text = result.content[0].text;
@@ -200,7 +200,7 @@ describe('GodotServer', () => {
     it('creates a .NET project when dotnet flag is true', async () => {
       const server = new (GodotServer as any)();
       const result = await server.handleCreateProject({
-        projectPath: '/tmp/test-dotnet',
+        projectPath: '/safe/test-dotnet',
         projectName: 'DotNetGame',
         dotnet: true,
       });
@@ -211,7 +211,7 @@ describe('GodotServer', () => {
 
     it('rejects when projectPath or projectName is missing', async () => {
       const server = new (GodotServer as any)();
-      const result = await server.handleCreateProject({ projectPath: '/tmp' });
+      const result = await server.handleCreateProject({ projectPath: '/safe' });
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('projectPath and projectName are required');
     });
@@ -220,7 +220,7 @@ describe('GodotServer', () => {
       mockExistsSync.mockReturnValue(true);
       const server = new (GodotServer as any)();
       const result = await server.handleCreateProject({
-        projectPath: '/tmp/existing',
+        projectPath: '/safe/existing',
         projectName: 'Existing',
       });
       expect(result.isError).toBe(true);
@@ -248,15 +248,6 @@ describe('GodotServer', () => {
       mockExistsSync.mockReturnValue(false);
       const server = new (GodotServer as any)();
       const result = await server.isValidGodotPath('/invalid/path');
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('setGodotPath', () => {
-    it('returns false for invalid path', async () => {
-      mockExistsSync.mockReturnValue(false);
-      const server = new (GodotServer as any)();
-      const result = await server.setGodotPath('/invalid/path');
       expect(result).toBe(false);
     });
   });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,0 +1,702 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+
+const mockExistsSync = vi.fn();
+const mockReaddirSync = vi.fn();
+const mockReadFileSync = vi.fn();
+const mockMkdirSync = vi.fn();
+const mockWriteFileSync = vi.fn();
+const mockUnlinkSync = vi.fn();
+const mockRenameSync = vi.fn();
+const mockExecFile = vi.fn();
+
+// Mock child_process before importing GodotServer
+vi.mock('child_process', () => ({
+  execFile: mockExecFile,
+  spawn: vi.fn(() => ({
+    on: vi.fn(),
+    stdout: { on: vi.fn(), setEncoding: vi.fn() },
+    stderr: { on: vi.fn(), setEncoding: vi.fn() },
+    pid: 12345,
+  })),
+}));
+
+// Mock util.promisify to return a wrapper that returns { stdout, stderr }
+vi.mock('util', async () => {
+  const actual = await vi.importActual<typeof import('util')>('util');
+  return {
+    ...actual,
+    promisify: vi.fn((fn: Function) => {
+      return (...args: any[]) => {
+        return new Promise((resolve, reject) => {
+          const callback = (err: Error | null, stdout?: string, stderr?: string) => {
+            if (err) reject(err);
+            else resolve({ stdout: stdout || '', stderr: stderr || '' });
+          };
+          fn(...args, callback);
+        });
+      };
+    }),
+  };
+});
+
+// Mock net to prevent actual TCP connections
+vi.mock('net', () => ({
+  createConnection: vi.fn(() => ({
+    on: vi.fn(),
+    write: vi.fn(),
+    end: vi.fn(),
+    destroy: vi.fn(),
+    setEncoding: vi.fn(),
+    setTimeout: vi.fn(),
+  })),
+  Socket: vi.fn(),
+}));
+
+// Mock fs to allow per-test control of key functions
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: mockExistsSync,
+    readdirSync: mockReaddirSync,
+    readFileSync: mockReadFileSync,
+    mkdirSync: mockMkdirSync,
+    writeFileSync: mockWriteFileSync,
+    unlinkSync: mockUnlinkSync,
+    renameSync: mockRenameSync,
+  };
+});
+
+describe('GodotServer', () => {
+  let GodotServer: { new: (config?: any) => any };
+
+  beforeAll(async () => {
+    process.env.GODOT_PATH = '/mock/godot';
+    const mod = await import('../src/index.js');
+    GodotServer = mod.GodotServer;
+  });
+
+  afterAll(() => {
+    delete process.env.GODOT_PATH;
+  });
+
+  beforeEach(() => {
+    mockExecFile.mockImplementation((...args: any[]) => {
+      // promisify(execFile) passes callback, call it with (null, stdout, stderr)
+      const cb = args.find((a: any) => typeof a === 'function');
+      if (cb) cb(null, 'Godot 4.3.stable\n', '');
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('isDotnetProject', () => {
+    it('returns true when .csproj files exist in directory', () => {
+      mockReaddirSync.mockReturnValue(['MyGame.csproj', 'Main.cs']);
+      const server = new (GodotServer as any)();
+      const result = server.isDotnetProject('/fake/project');
+      expect(result).toBe(true);
+    });
+
+    it('returns false when no .csproj files exist', () => {
+      mockReaddirSync.mockReturnValue(['Main.gd', 'Main.tscn']);
+      const server = new (GodotServer as any)();
+      const result = server.isDotnetProject('/fake/project');
+      expect(result).toBe(false);
+    });
+
+    it('returns false when directory cannot be read', () => {
+      mockReaddirSync.mockImplementation(() => { throw new Error('permission denied'); });
+      const server = new (GodotServer as any)();
+      const result = server.isDotnetProject('/fake/project');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('detectGodotPath', () => {
+    afterEach(() => {
+      delete process.env.GODOT_PATH;
+    });
+
+    it('uses GODOT_PATH env var if valid', async () => {
+      process.env.GODOT_PATH = '/mock/godot';
+      mockExistsSync.mockReturnValue(true);
+      const server = new (GodotServer as any)();
+      await server.detectGodotPath();
+      expect(server.godotPath).toBe('/mock/godot');
+    });
+
+    it('returns without changing when existing godotPath is valid', async () => {
+      mockExistsSync.mockReturnValue(true);
+      const server = new (GodotServer as any)({ godotPath: '/custom/godot' });
+      await server.detectGodotPath();
+      expect(server.godotPath).toBe('/custom/godot');
+    });
+  });
+
+  describe('getProjectStructure', () => {
+    it('categorizes directories correctly', async () => {
+      mockReaddirSync.mockReturnValue([
+        { name: 'scenes', isDirectory: () => true },
+        { name: 'scripts', isDirectory: () => true },
+        { name: 'textures', isDirectory: () => true },
+        { name: '.godot', isDirectory: () => true },
+        { name: 'main.tscn', isDirectory: () => false },
+      ]);
+      const server = new (GodotServer as any)();
+      const result = await server.getProjectStructure('/fake/project');
+      expect(result.scenes).toContain('scenes');
+      expect(result.scripts).toContain('scripts');
+      expect(result.assets).toContain('textures');
+    });
+  });
+
+  describe('findGodotProjects', () => {
+    it('finds immediate Godot projects in a directory', () => {
+      // Only subdirectories have project.godot, not the parent itself
+      mockExistsSync.mockImplementation(
+        (p: string) => !p.toString().endsWith('projects/project.godot'),
+      );
+      mockReaddirSync.mockReturnValue([
+        { name: 'MyGame', isDirectory: () => true },
+        { name: 'OtherGame', isDirectory: () => true },
+      ]);
+      const server = new (GodotServer as any)();
+      const result = server.findGodotProjects('/fake/projects', false);
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('MyGame');
+      expect(result[1].name).toBe('OtherGame');
+    });
+
+    it('returns empty when no projects found', () => {
+      mockReaddirSync.mockReturnValue([]);
+      mockExistsSync.mockReturnValue(false);
+      const server = new (GodotServer as any)();
+      const result = server.findGodotProjects('/fake/projects', false);
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('handleCreateProject', () => {
+    beforeEach(() => {
+      mockExistsSync.mockReturnValue(false);
+      mockMkdirSync.mockReturnValue(undefined);
+      mockWriteFileSync.mockReturnValue(undefined);
+    });
+
+    it('creates a regular project successfully', async () => {
+      const server = new (GodotServer as any)();
+      const result = await server.handleCreateProject({
+        projectPath: '/tmp/test-project',
+        projectName: 'TestGame',
+      });
+      const text = result.content[0].text;
+      expect(text).toContain('TestGame');
+      expect(text).not.toContain('.NET');
+    });
+
+    it('creates a .NET project when dotnet flag is true', async () => {
+      const server = new (GodotServer as any)();
+      const result = await server.handleCreateProject({
+        projectPath: '/tmp/test-dotnet',
+        projectName: 'DotNetGame',
+        dotnet: true,
+      });
+      const text = result.content[0].text;
+      expect(text).toContain('DotNetGame');
+      expect(text).toContain('.NET');
+    });
+
+    it('rejects when projectPath or projectName is missing', async () => {
+      const server = new (GodotServer as any)();
+      const result = await server.handleCreateProject({ projectPath: '/tmp' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('projectPath and projectName are required');
+    });
+
+    it('rejects when project already exists', async () => {
+      mockExistsSync.mockReturnValue(true);
+      const server = new (GodotServer as any)();
+      const result = await server.handleCreateProject({
+        projectPath: '/tmp/existing',
+        projectName: 'Existing',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('already exists');
+    });
+
+    it('rejects invalid path', async () => {
+      const server = new (GodotServer as any)();
+      const result = await server.handleCreateProject({
+        projectPath: '../../etc/passwd',
+        projectName: 'Bad',
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('isValidGodotPath', () => {
+    it('returns true for godot (PATH check) without fs access', async () => {
+      const server = new (GodotServer as any)();
+      const result = await server.isValidGodotPath('godot');
+      expect(result).toBe(true);
+    });
+
+    it('returns false when path does not exist', async () => {
+      mockExistsSync.mockReturnValue(false);
+      const server = new (GodotServer as any)();
+      const result = await server.isValidGodotPath('/invalid/path');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('setGodotPath', () => {
+    it('returns false for invalid path', async () => {
+      mockExistsSync.mockReturnValue(false);
+      const server = new (GodotServer as any)();
+      const result = await server.setGodotPath('/invalid/path');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('handleGetProjectInfo', () => {
+    it('returns error for non-existent project', async () => {
+      mockExistsSync.mockReturnValue(false);
+      const server = new (GodotServer as any)();
+      const result = await server.handleGetProjectInfo({ projectPath: '/fake' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Not a valid Godot project');
+    });
+
+    it('reads project info and includes isDotnet', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(`
+[application]
+config/name="TestGame"
+config/features=PackedStringArray("4.3", "DotNet")
+      `);
+      // getProjectStructureAsync (Dirent-like) called first, then isDotnetProject (strings)
+      mockReaddirSync
+        .mockReturnValueOnce([
+          { name: 'TestGame.csproj', isDirectory: () => false, isFile: () => true },
+        ])
+        .mockReturnValueOnce(['TestGame.csproj']);
+      const server = new (GodotServer as any)();
+      const result = await server.handleGetProjectInfo({ projectPath: '/fake' });
+      const json = JSON.parse(result.content[0].text);
+      expect(json.name).toBe('TestGame');
+      expect(json.isDotnet).toBe(true);
+    });
+
+    it('reads project info without .NET', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(`
+[application]
+config/name="MyGame"
+      `);
+      mockReaddirSync
+        .mockReturnValueOnce([
+          { name: 'Main.gd', isDirectory: () => false, isFile: () => true },
+        ])
+        .mockReturnValueOnce(['Main.gd']);
+      const server = new (GodotServer as any)();
+      const result = await server.handleGetProjectInfo({ projectPath: '/fake' });
+      const json = JSON.parse(result.content[0].text);
+      expect(json.name).toBe('MyGame');
+      expect(json.isDotnet).toBe(false);
+    });
+  });
+
+  describe('handleCreateCsharpScript', () => {
+    it('rejects non-.NET projects', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([]);
+      const server = new (GodotServer as any)();
+      const result = await server.handleCreateCsharpScript({
+        projectPath: '/fake',
+        scriptPath: 'scripts/Player.cs',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Not a Godot .NET project');
+    });
+
+    it('creates a C# script in a .NET project', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue(['MyGame.csproj']);
+      mockMkdirSync.mockReturnValue(undefined);
+      mockWriteFileSync.mockReturnValue(undefined);
+      const server = new (GodotServer as any)();
+      const result = await server.handleCreateCsharpScript({
+        projectPath: '/fake',
+        scriptPath: 'scripts/Player.cs',
+        namespace: 'MyGame',
+        inherits: 'CharacterBody3D',
+        methods: ['_Ready', '_Process'],
+      });
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain('Player.cs');
+    });
+  });
+
+  describe('handleCsharpScript validation', () => {
+    it('rejects when projectPath or scriptPath is missing', async () => {
+      const server = new (GodotServer as any)();
+      const result = await server.handleCreateCsharpScript({ projectPath: '/fake' });
+      expect(result.isError).toBe(true);
+    });
+
+    it('rejects when project.godot does not exist', async () => {
+      mockExistsSync.mockReturnValue(false);
+      const server = new (GodotServer as any)();
+      const result = await server.handleCreateCsharpScript({
+        projectPath: '/fake',
+        scriptPath: 'test.cs',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Not a valid Godot project');
+    });
+
+    it('rejects path traversal', async () => {
+      const server = new (GodotServer as any)();
+      const result = await server.handleCreateCsharpScript({
+        projectPath: '../../etc',
+        scriptPath: 'test.cs',
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('constructor config', () => {
+    it('accepts strictPathValidation config', () => {
+      const server = new (GodotServer as any)({ strictPathValidation: true });
+      expect(server.strictPathValidation).toBe(true);
+    });
+
+    it('resets godotPath when sync validation fails', () => {
+      mockExistsSync.mockReturnValue(false);
+      const server = new (GodotServer as any)({ godotPath: '/bad/path' });
+      expect(server.godotPath).toBeNull();
+    });
+  });
+
+  describe('handleGetGodotVersion', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('returns Godot version via execFileAsync', async () => {
+      const server = new (GodotServer as any)();
+      server.godotPath = '/mock/godot';
+      const result = await server.handleGetGodotVersion();
+      expect(result.content[0].text).toBe('Godot 4.3.stable');
+    });
+  });
+
+  describe('handleListProjects', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('rejects when directory is missing', async () => {
+      const server = new (GodotServer as any)();
+      const result = await server.handleListProjects({});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Directory is required');
+    });
+
+    it('rejects invalid directory path', async () => {
+      const server = new (GodotServer as any)();
+      const result = await server.handleListProjects({ directory: '../../etc' });
+      expect(result.isError).toBe(true);
+    });
+
+    it('rejects non-existent directory', async () => {
+      mockExistsSync.mockReturnValue(false);
+      const server = new (GodotServer as any)();
+      const result = await server.handleListProjects({ directory: '/noexist' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Directory does not exist');
+    });
+
+    it('lists projects in a directory', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue([
+        { name: 'MyGame', isDirectory: () => true },
+      ]);
+      const server = new (GodotServer as any)();
+      const result = await server.handleListProjects({ directory: '/projects' });
+      expect(result.isError).toBeFalsy();
+      const projects = JSON.parse(result.content[0].text);
+      expect(Array.isArray(projects)).toBe(true);
+    });
+  });
+
+  describe('handleReadFile', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('rejects missing params', async () => {
+      const server = new (GodotServer as any)();
+      const r = await server.handleReadFile({ projectPath: '/p' });
+      expect(r.isError).toBe(true);
+    });
+
+    it('rejects invalid path', async () => {
+      const server = new (GodotServer as any)();
+      const r = await server.handleReadFile({ projectPath: '../../etc', filePath: 'x' });
+      expect(r.isError).toBe(true);
+    });
+
+    it('rejects when project.godot does not exist', async () => {
+      mockExistsSync.mockReturnValue(false);
+      const server = new (GodotServer as any)();
+      const r = await server.handleReadFile({ projectPath: '/p', filePath: 'f.txt' });
+      expect(r.isError).toBe(true);
+      expect(r.content[0].text).toContain('Not a valid Godot project');
+    });
+
+    it('rejects when target file does not exist', async () => {
+      mockExistsSync.mockImplementation(
+        (p: string) => p.toString().endsWith('project.godot'),
+      );
+      const server = new (GodotServer as any)();
+      const r = await server.handleReadFile({ projectPath: '/p', filePath: 'f.txt' });
+      expect(r.isError).toBe(true);
+      expect(r.content[0].text).toContain('File does not exist');
+    });
+
+    it('reads file content successfully', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue('hello world');
+      const server = new (GodotServer as any)();
+      const r = await server.handleReadFile({ projectPath: '/p', filePath: 'f.txt' });
+      expect(r.content[0].text).toBe('hello world');
+    });
+  });
+
+  describe('handleWriteFile', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('rejects missing content', async () => {
+      const server = new (GodotServer as any)();
+      const r = await server.handleWriteFile({ projectPath: '/p', filePath: 'f.txt' });
+      expect(r.isError).toBe(true);
+    });
+
+    it('writes file successfully', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockMkdirSync.mockReturnValue(undefined);
+      mockWriteFileSync.mockReturnValue(undefined);
+      const server = new (GodotServer as any)();
+      const r = await server.handleWriteFile({ projectPath: '/p', filePath: 'f.txt', content: 'data' });
+      expect(r.content[0].text).toContain('File written');
+    });
+  });
+
+  describe('handleDeleteFile', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('rejects missing params', async () => {
+      const server = new (GodotServer as any)();
+      const r = await server.handleDeleteFile({});
+      expect(r.isError).toBe(true);
+    });
+
+    it('deletes file successfully', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockUnlinkSync.mockReturnValue(undefined);
+      const server = new (GodotServer as any)();
+      const r = await server.handleDeleteFile({ projectPath: '/p', filePath: 'f.txt' });
+      expect(r.content[0].text).toContain('File deleted');
+    });
+  });
+
+  describe('handleCreateDirectory', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('rejects missing params', async () => {
+      const server = new (GodotServer as any)();
+      const r = await server.handleCreateDirectory({ projectPath: '/p' });
+      expect(r.isError).toBe(true);
+    });
+
+    it('creates directory successfully', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockMkdirSync.mockReturnValue(undefined);
+      const server = new (GodotServer as any)();
+      const r = await server.handleCreateDirectory({ projectPath: '/p', directoryPath: 'new_dir' });
+      expect(r.content[0].text).toContain('Directory created');
+    });
+  });
+
+  describe('handleRenameFile', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('rejects missing params', async () => {
+      const server = new (GodotServer as any)();
+      const r = await server.handleRenameFile({ projectPath: '/p', filePath: 'a.txt' });
+      expect(r.isError).toBe(true);
+    });
+
+    it('renames file successfully', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockMkdirSync.mockReturnValue(undefined);
+      mockRenameSync.mockReturnValue(undefined);
+      const server = new (GodotServer as any)();
+      const r = await server.handleRenameFile({ projectPath: '/p', filePath: 'a.txt', newPath: 'b.txt' });
+      expect(r.content[0].text).toContain('Renamed');
+    });
+  });
+
+  describe('setGodotPath', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('sets a valid Godot path successfully', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockExecFile.mockImplementation((...args: any[]) => {
+        const cb = args.find((a: any) => typeof a === 'function');
+        if (cb) cb(null, 'Godot 4.3.stable\n', '');
+      });
+      const server = new (GodotServer as any)();
+      const result = await server.setGodotPath('/valid/godot');
+      expect(result).toBe(true);
+      expect(server.godotPath).toBe('/valid/godot');
+    });
+
+    it('rejects invalid Godot path (non-existent file)', async () => {
+      mockExistsSync.mockReturnValue(false);
+      const server = new (GodotServer as any)();
+      const result = await server.setGodotPath('/bad/godot');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('gameCommand error paths', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('rejects when no active process', async () => {
+      const server = new (GodotServer as any)();
+      const result = await server.gameCommand('test_cmd', {}, () => ({}));
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('No active Godot process');
+    });
+
+    it('rejects when not connected', async () => {
+      const server = new (GodotServer as any)();
+      server.activeProcess = { process: { kill: vi.fn() }, output: [], errors: [] };
+      const result = await server.gameCommand('test_cmd', {}, () => ({}));
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Not connected');
+    });
+  });
+
+  describe('headlessOp with mocked executeOperation', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('rejects missing projectPath', async () => {
+      const server = new (GodotServer as any)();
+      const result = await server.headlessOp('op', {}, () => ({ projectPath: '', params: {} }));
+      expect(result.isError).toBe(true);
+    });
+
+    it('rejects invalid path', async () => {
+      const server = new (GodotServer as any)();
+      const result = await server.headlessOp('op', { projectPath: '../../etc' }, (a: any) => ({ projectPath: a.projectPath, params: {} }));
+      expect(result.isError).toBe(true);
+    });
+
+    it('rejects non-existent project', async () => {
+      mockExistsSync.mockReturnValue(false);
+      const server = new (GodotServer as any)();
+      const result = await server.headlessOp('op', { projectPath: '/fake' }, (a: any) => ({ projectPath: a.projectPath, params: {} }));
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Not a valid Godot project');
+    });
+  });
+
+  describe('handleGetDebugOutput', () => {
+    it('rejects when no active process', async () => {
+      const server = new (GodotServer as any)();
+      const result = await server.handleGetDebugOutput();
+      expect(result.isError).toBe(true);
+    });
+
+    it('returns output and errors arrays', async () => {
+      const server = new (GodotServer as any)();
+      server.activeProcess = { process: { kill: vi.fn() }, output: ['log1'], errors: ['err1'] };
+      const result = await server.handleGetDebugOutput();
+      const json = JSON.parse(result.content[0].text);
+      expect(json.output).toContain('log1');
+      expect(json.errors).toContain('err1');
+    });
+  });
+
+  describe('handleGameGetErrors', () => {
+    it('rejects when no active process', async () => {
+      const server = new (GodotServer as any)();
+      const result = await server.handleGameGetErrors();
+      expect(result.isError).toBe(true);
+    });
+
+    it('returns accumulated errors since last call', async () => {
+      const server = new (GodotServer as any)();
+      server.activeProcess = { process: { kill: vi.fn() }, output: [], errors: ['err1', 'err2'] };
+      const result = await server.handleGameGetErrors();
+      const json = JSON.parse(result.content[0].text);
+      expect(json.count).toBe(2);
+    });
+  });
+
+  describe('handleGameGetLogs', () => {
+    it('rejects when no active process', async () => {
+      const server = new (GodotServer as any)();
+      const result = await server.handleGameGetLogs();
+      expect(result.isError).toBe(true);
+    });
+
+    it('returns accumulated logs since last call', async () => {
+      const server = new (GodotServer as any)();
+      server.activeProcess = { process: { kill: vi.fn() }, output: ['log1', 'log2'], errors: [] };
+      const result = await server.handleGameGetLogs();
+      const json = JSON.parse(result.content[0].text);
+      expect(json.count).toBe(2);
+    });
+  });
+
+  describe('handleGetGodotVersion error paths', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('returns error when no godot path found in strict mode', async () => {
+      mockExistsSync.mockReturnValue(false);
+      // Override execFile to fail for all paths so auto-detect fails
+      mockExecFile.mockImplementation((...args: any[]) => {
+        const cb = args.find((a: any) => typeof a === 'function');
+        if (cb) cb(new Error('not found'), '', '');
+      });
+      const server = new (GodotServer as any)({ strictPathValidation: true });
+      const result = await server.handleGetGodotVersion();
+      expect(result).toBeDefined();
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Failed to get Godot version');
+    });
+  });
+});

--- a/tests/tool-definitions.test.ts
+++ b/tests/tool-definitions.test.ts
@@ -53,7 +53,7 @@ const ALL_TOOL_NAMES = [
   'game_animation_control', 'game_skeleton_ik', 'game_audio_effect',
   'game_audio_bus_layout', 'game_audio_spatial',
   // Batch 4: Editor/Headless + Localization + Resource
-  'rename_file', 'manage_resource', 'create_script', 'manage_scene_signals',
+  'rename_file', 'manage_resource', 'create_script', 'create_csharp_script', 'manage_scene_signals',
   'manage_layers', 'manage_plugins', 'manage_shader', 'manage_theme_resource',
   'set_main_scene', 'manage_scene_structure', 'manage_translations', 'game_locale',
   // Batch 5: UI Controls + Rendering + Resource Runtime
@@ -71,8 +71,8 @@ beforeAll(() => {
 });
 
 describe('Tool definitions', () => {
-  it('defines exactly 154 tools', () => {
-    expect(ALL_TOOL_NAMES).toHaveLength(154);
+  it('defines exactly 155 tools', () => {
+    expect(ALL_TOOL_NAMES).toHaveLength(155);
   });
 
   it('all tool names are unique', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "allowJs": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "tests"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,11 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.d.ts'],
+    },
   },
 });


### PR DESCRIPTION
Add first-class .NET/C# support: detect .csproj projects, add create_project dotnet flag, and implement create_csharp_script handler and tool. New utility functions in utils.ts (generateCsharpScriptSource, generateCsprojContent, generateGodotProjectFeatures, getGodotBinaryCandidates) and isDotnetProject were added. Prevent the server from auto-starting during tests and export GodotServer for test imports. Add comprehensive tests (tests/dotnet.test.ts, tests/server.test.ts) and update handlers tests. Documentation updated (README) with OpenCode and .NET/C# usage, plus an opencode.json config. Also add npm test:coverage script and minor package metadata updates.