### PR TITLE
Reduce MCP tool overload with tree-routed operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![](https://img.shields.io/badge/TypeScript-3178C6?style=flat&logo=typescript&logoColor=white 'TypeScript')](https://www.typescriptlang.org/)
 [![](https://img.shields.io/badge/License-MIT-red.svg 'MIT License')](https://opensource.org/licenses/MIT)
 
-A comprehensive [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) server that gives AI assistants **full control** over the Godot game engine. **157 tools** spanning networking, 3D/2D rendering, UI controls, audio effects, animation trees, file I/O, runtime code execution, property inspection, scene manipulation, signal management, physics, project creation, and more.
+A comprehensive [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) server that gives AI assistants **full control** over the Godot game engine. It exposes **157 operations** spanning networking, 3D/2D rendering, UI controls, audio effects, animation trees, file I/O, runtime code execution, property inspection, scene manipulation, signal management, physics, project creation, and more.
 
 ## Acknowledgments
 
@@ -215,7 +215,28 @@ The original godot-mcp provided 20 tools for basic project management and scene 
 - **PackedArray serialization** - Proper JSON arrays instead of string fallback
 - **Graceful error handling** - Scene read fallback to raw .tscn text on missing dependencies
 
-## All 157 Tools
+## Public tool tree
+
+To avoid overwhelming MCP clients and agents with 157 top-level tools, the server now exposes **19 public tools**:
+
+- `godot_catalog` lists the tree, or the operations in one requested domain.
+- Eighteen `<domain>_manage` tools accept `{ "op": "<operation>", "params": { ... } }`.
+
+Start by calling `godot_catalog`. Then call the matching branch, for example:
+
+```json
+{
+  "op": "validate_script",
+  "params": {
+    "projectPath": "C:/games/my-game",
+    "scriptPath": "res://player.gd"
+  }
+}
+```
+
+The branches are: `core`, `project`, `scene`, `filesystem`, `validation`, `runtime`, `node`, `input`, `signal`, `animation`, `camera`, `physics`, `render_2d`, `render_3d`, `audio`, `ui`, `network`, and `system`. The 157 operation names below remain the compatibility reference; they are values of `op`, not MCP tool names.
+
+## All 157 operations
 
 ### Project Management (7 tools)
 | Tool | Description |

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ The original godot-mcp provided 20 tools for basic project management and scene 
 
 To avoid overwhelming MCP clients and agents with 157 top-level tools, the server now exposes **19 public tools**:
 
-- `godot_catalog` lists the tree, or the operations in one requested domain.
+- `godot_catalog` lists the tree, or returns operation descriptions and input schemas for one requested domain.
 - Eighteen `<domain>_manage` tools accept `{ "op": "<operation>", "params": { ... } }`.
 
 Start by calling `godot_catalog`. Then call the matching branch. For example, the former top-level call:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project is built upon and extends [godot-mcp](https://github.com/Coding-Sol
 
 ## What's New (Improvements Over Original)
 
-The original godot-mcp provided 20 tools for basic project management and scene creation. This fork extends it to **157 tools** with the following major additions:
+The original godot-mcp provided 20 tools for basic project management and scene creation. This fork extends that capability set to **157 operations**, now exposed through a compact public tool tree:
 
 ### New in 3.1
 - **`validate_script` autoload resolution** - Script validation now compiles the target through a `SceneTree` at `_initialize()` (after project autoloads are registered) instead of `--check-only` at `_init()`. References to autoload singletons no longer produce false `Identifier not found` errors, while real syntax/type errors are still caught. Verified building a full game whose scripts reference several autoloads.
@@ -25,7 +25,7 @@ The original godot-mcp provided 20 tools for basic project management and scene 
 ### New in 3.0
 - **.NET / C# support** - Scaffold C# projects and generate C# scripts (`create_project` with `dotnet: true`, `create_csharp_script`); the `.csproj` SDK version is matched to your installed Godot.
 - **GDScript diagnostics** - Validate scripts for syntax and type errors without running the game (`validate_script`, and `validate_scripts` for all git-changed or project-wide files).
-- **Correctness and robustness fixes** across the headless scene operations and the runtime interaction server (resource-typed properties now persist, reparenting works, runtime commands are correlated by request id, and the tools survive projects with warnings-as-errors). Requires Godot 4.4 or later; tested and working with the latest Godot **4.7**.
+- **Correctness and robustness fixes** across the headless scene operations and the runtime interaction server (resource-typed properties now persist, reparenting works, runtime commands are correlated by request id, and the operations survive projects with warnings-as-errors). Requires Godot 4.4 or later; tested and working with the latest Godot **4.7**.
 
 ### Runtime Code Execution
 - **`game_eval`** - Execute arbitrary GDScript code in the running game with return values
@@ -222,7 +222,13 @@ To avoid overwhelming MCP clients and agents with 157 top-level tools, the serve
 - `godot_catalog` lists the tree, or the operations in one requested domain.
 - Eighteen `<domain>_manage` tools accept `{ "op": "<operation>", "params": { ... } }`.
 
-Start by calling `godot_catalog`. Then call the matching branch, for example:
+Start by calling `godot_catalog`. Then call the matching branch. For example, the former top-level call:
+
+```text
+validate_script({ "projectPath": "C:/games/my-game", "scriptPath": "res://player.gd" })
+```
+
+becomes a call to `validation_manage` with these arguments:
 
 ```json
 {
@@ -238,8 +244,8 @@ The branches are: `core`, `project`, `scene`, `filesystem`, `validation`, `runti
 
 ## All 157 operations
 
-### Project Management (7 tools)
-| Tool | Description |
+### Project Management (7 operations)
+| Operation | Description |
 |------|-------------|
 | `launch_editor` | Launch Godot editor for a project |
 | `run_project` | Run a Godot project and capture output |
@@ -249,8 +255,8 @@ The branches are: `core`, `project`, `scene`, `filesystem`, `validation`, `runti
 | `list_projects` | Find Godot projects in a directory |
 | `get_project_info` | Get project metadata |
 
-### Scene Management (7 tools)
-| Tool | Description |
+### Scene Management (7 operations)
+| Operation | Description |
 |------|-------------|
 | `create_scene` | Create a new scene with a root node type |
 | `add_node` | Add a node to an existing scene |
@@ -260,8 +266,8 @@ The branches are: `core`, `project`, `scene`, `filesystem`, `validation`, `runti
 | `get_uid` | Get UID for a file (Godot 4.4+) |
 | `update_project_uids` | Resave resources to update UIDs |
 
-### Headless Scene Operations (5 tools)
-| Tool | Description |
+### Headless Scene Operations (5 operations)
+| Operation | Description |
 |------|-------------|
 | `read_scene` | Read full scene tree as JSON |
 | `modify_scene_node` | Modify node properties in a scene file |
@@ -269,35 +275,35 @@ The branches are: `core`, `project`, `scene`, `filesystem`, `validation`, `runti
 | `attach_script` | Attach a GDScript to a scene node |
 | `create_resource` | Create a .tres resource file |
 
-### Project Settings (3 tools)
-| Tool | Description |
+### Project Settings (3 operations)
+| Operation | Description |
 |------|-------------|
 | `read_project_settings` | Parse project.godot as JSON |
 | `modify_project_settings` | Change a project setting |
 | `list_project_files` | List/filter project files |
 
-### Runtime Input (4 tools)
-| Tool | Description |
+### Runtime Input (4 operations)
+| Operation | Description |
 |------|-------------|
 | `game_screenshot` | Capture a screenshot (base64 PNG) |
 | `game_click` | Click at a position |
 | `game_key_press` | Send key press or input action |
 | `game_mouse_move` | Move the mouse |
 
-### Runtime Inspection (3 tools)
-| Tool | Description |
+### Runtime Inspection (3 operations)
+| Operation | Description |
 |------|-------------|
 | `game_get_ui` | Get all visible UI elements |
 | `game_get_scene_tree` | Get full scene tree structure |
 | `game_get_node_info` | Detailed node introspection |
 
-### Runtime Code Execution (1 tool)
-| Tool | Description |
+### Runtime Code Execution (1 operation)
+| Operation | Description |
 |------|-------------|
 | `game_eval` | Execute arbitrary GDScript with return values |
 
-### Runtime Node Manipulation (7 tools)
-| Tool | Description |
+### Runtime Node Manipulation (7 operations)
+| Operation | Description |
 |------|-------------|
 | `game_get_property` | Get any node property |
 | `game_set_property` | Set any node property (auto type conversion) |
@@ -307,8 +313,8 @@ The branches are: `core`, `project`, `scene`, `filesystem`, `validation`, `runti
 | `game_change_scene` | Switch to a different scene |
 | `game_reparent_node` | Move a node to a new parent |
 
-### Runtime Signals (5 tools)
-| Tool | Description |
+### Runtime Signals (5 operations)
+| Operation | Description |
 |------|-------------|
 | `game_connect_signal` | Connect a signal to a method |
 | `game_disconnect_signal` | Disconnect a signal |
@@ -316,14 +322,14 @@ The branches are: `core`, `project`, `scene`, `filesystem`, `validation`, `runti
 | `game_list_signals` | List all signals on a node with connections |
 | `game_await_signal` | Await a signal with timeout and return args |
 
-### Runtime Animation (2 tools)
-| Tool | Description |
+### Runtime Animation (2 operations)
+| Operation | Description |
 |------|-------------|
 | `game_play_animation` | Control AnimationPlayer |
 | `game_tween_property` | Tween a property with easing |
 
-### Runtime Utilities (5 tools)
-| Tool | Description |
+### Runtime Utilities (5 operations)
+| Operation | Description |
 |------|-------------|
 | `game_pause` | Pause/unpause the game |
 | `game_performance` | Get FPS, memory, draw calls |
@@ -331,22 +337,22 @@ The branches are: `core`, `project`, `scene`, `filesystem`, `validation`, `runti
 | `game_get_nodes_in_group` | Query nodes by group |
 | `game_find_nodes_by_class` | Find nodes by class type |
 
-### File I/O (4 tools)
-| Tool | Description |
+### File I/O (4 operations)
+| Operation | Description |
 |------|-------------|
 | `read_file` | Read a text file from a Godot project |
 | `write_file` | Create or overwrite a text file |
 | `delete_file` | Delete a file from a project |
 | `create_directory` | Create a directory inside a project |
 
-### Error & Log Capture (2 tools)
-| Tool | Description |
+### Error & Log Capture (2 operations)
+| Operation | Description |
 |------|-------------|
 | `game_get_errors` | Get new errors/warnings since last call |
 | `game_get_logs` | Get new print output since last call |
 
-### Enhanced Input (8 tools)
-| Tool | Description |
+### Enhanced Input (8 operations)
+| Operation | Description |
 |------|-------------|
 | `game_key_hold` | Hold a key down (no auto-release) |
 | `game_key_release` | Release a held key |
@@ -357,8 +363,8 @@ The branches are: `core`, `project`, `scene`, `filesystem`, `validation`, `runti
 | `game_input_state` | Query pressed keys, mouse position, connected pads |
 | `game_input_action` | Manage runtime InputMap actions and strength |
 
-### Project Creation (5 tools)
-| Tool | Description |
+### Project Creation (5 operations)
+| Operation | Description |
 |------|-------------|
 | `create_project` | Create a new Godot project (supports `dotnet: true` for C#) |
 | `create_csharp_script` | Create a C# script in a Godot .NET project |
@@ -366,8 +372,8 @@ The branches are: `core`, `project`, `scene`, `filesystem`, `validation`, `runti
 | `manage_input_map` | Add, remove, or list input actions |
 | `manage_export_presets` | Create or modify export presets |
 
-### Advanced Runtime (24 tools)
-| Tool | Description |
+### Advanced Runtime (24 operations)
+| Operation | Description |
 |------|-------------|
 | `game_get_camera` | Get active camera position/rotation/zoom |
 | `game_set_camera` | Move or rotate the active camera |
@@ -393,21 +399,21 @@ The branches are: `core`, `project`, `scene`, `filesystem`, `validation`, `runti
 | `game_viewport` | Create or configure a SubViewport node |
 | `game_debug_draw` | Draw debug lines, spheres, or boxes in 3D |
 
-### Build & Export (1 tool)
-| Tool | Description |
+### Build & Export (1 operation)
+| Operation | Description |
 |------|-------------|
 | `export_project` | Export a Godot project using a preset |
 
-### Networking (4 tools)
-| Tool | Description |
+### Networking (4 operations)
+| Operation | Description |
 |------|-------------|
 | `game_http_request` | HTTP GET/POST/PUT/DELETE with headers and body |
 | `game_websocket` | WebSocket client connect/disconnect/send messages |
 | `game_multiplayer` | ENet multiplayer create server/client/disconnect |
 | `game_rpc` | Call or configure RPC methods on nodes |
 
-### System & Window (6 tools)
-| Tool | Description |
+### System & Window (6 operations)
+| Operation | Description |
 |------|-------------|
 | `game_script` | Attach, detach, or get source of node scripts |
 | `game_window` | Get/set window size, fullscreen, title, position |
@@ -416,8 +422,8 @@ The branches are: `core`, `project`, `scene`, `filesystem`, `validation`, `runti
 | `game_process_mode` | Set node process mode (pausable/always/disabled) |
 | `game_world_settings` | Get/set gravity, physics FPS, and world settings |
 
-### 3D Rendering & Geometry (13 tools)
-| Tool | Description |
+### 3D Rendering & Geometry (13 operations)
+| Operation | Description |
 |------|-------------|
 | `game_csg` | Create/configure CSG nodes with boolean operations |
 | `game_multimesh` | Create/configure MultiMeshInstance3D for instancing |
@@ -433,8 +439,8 @@ The branches are: `core`, `project`, `scene`, `filesystem`, `validation`, `runti
 | `game_navigation_3d` | Create/configure NavigationRegion3D and bake |
 | `game_physics_3d` | Area3D queries and point/shape intersection tests |
 
-### 2D Systems (7 tools)
-| Tool | Description |
+### 2D Systems (7 operations)
+| Operation | Description |
 |------|-------------|
 | `game_canvas` | Create/configure CanvasLayer and CanvasModulate |
 | `game_canvas_draw` | 2D drawing: line/rect/circle/polygon/text/clear |
@@ -444,22 +450,22 @@ The branches are: `core`, `project`, `scene`, `filesystem`, `validation`, `runti
 | `game_path_2d` | Path2D/Curve2D management and AnimatedSprite2D |
 | `game_physics_2d` | Area2D queries and 2D point/shape intersections |
 
-### Advanced Animation (3 tools)
-| Tool | Description |
+### Advanced Animation (3 operations)
+| Operation | Description |
 |------|-------------|
 | `game_animation_tree` | AnimationTree state machine travel and params |
 | `game_animation_control` | AnimationPlayer seek/queue/speed/info control |
 | `game_skeleton_ik` | SkeletonIK3D start/stop/set target position |
 
-### Advanced Audio (3 tools)
-| Tool | Description |
+### Advanced Audio (3 operations)
+| Operation | Description |
 |------|-------------|
 | `game_audio_effect` | Add/remove/configure audio bus effects |
 | `game_audio_bus_layout` | Create/remove/reorder audio buses and routing |
 | `game_audio_spatial` | Configure AudioStreamPlayer3D spatial properties |
 
-### Editor & Project Tools (14 tools)
-| Tool | Description |
+### Editor & Project Operations (14 operations)
+| Operation | Description |
 |------|-------------|
 | `rename_file` | Rename or move a file within the project |
 | `manage_resource` | Read or modify .tres/.res resource files |
@@ -476,8 +482,8 @@ The branches are: `core`, `project`, `scene`, `filesystem`, `validation`, `runti
 | `manage_translations` | List/add/remove translation files in project |
 | `game_locale` | Set/get locale and translate strings at runtime |
 
-### UI Controls (8 tools)
-| Tool | Description |
+### UI Controls (8 operations)
+| Operation | Description |
 |------|-------------|
 | `game_ui_control` | Set focus, anchors, tooltip, mouse filter on Control |
 | `game_ui_text` | LineEdit/TextEdit/RichTextLabel text operations |
@@ -488,8 +494,8 @@ The branches are: `core`, `project`, `scene`, `filesystem`, `validation`, `runti
 | `game_ui_menu` | PopupMenu/MenuBar: add/remove/get menu items |
 | `game_ui_range` | ProgressBar/Slider/SpinBox/ColorPicker get/set |
 
-### Rendering & Resources (2 tools)
-| Tool | Description |
+### Rendering & Resources (2 operations)
+| Operation | Description |
 |------|-------------|
 | `game_render_settings` | Get/set MSAA, FXAA, TAA, scaling mode/scale |
 | `game_resource` | Runtime resource load, save, or preload |
@@ -562,9 +568,9 @@ Create `.cursor/mcp.json` in your project:
 }
 ```
 
-## Runtime Tools Setup
+## Runtime Operations Setup
 
-To use the `game_*` runtime tools, your Godot project needs the MCP interaction server autoload. Copy `build/scripts/mcp_interaction_server.gd` to your project and register it as an autoload:
+To use the `game_*` runtime operations, your Godot project needs the MCP interaction server autoload. Copy `build/scripts/mcp_interaction_server.gd` to your project and register it as an autoload:
 
 1. Copy `build/scripts/mcp_interaction_server.gd` to your project's scripts folder
 2. In Godot: **Project > Project Settings > Autoload**
@@ -592,7 +598,7 @@ The server uses two communication channels:
 
 | Path | Description |
 |------|-------------|
-| `src/index.ts` | MCP server, tool definitions, and all handlers |
+| `src/index.ts` | MCP server, public tool tree, operation schemas, and handlers |
 | `src/utils.ts` | Pure utility functions (parameter mapping, validation, error helpers) |
 | `src/scripts/godot_operations.gd` | Headless GDScript operations runner |
 | `src/scripts/mcp_interaction_server.gd` | TCP interaction server autoload |
@@ -600,12 +606,12 @@ The server uses two communication channels:
 
 ## Testing
 
-The project uses [Vitest](https://vitest.dev/) with 446 tests across 5 files:
+The project uses [Vitest](https://vitest.dev/) with 455 tests across 5 files:
 
 | File | Tests | What it covers |
 |------|-------|----------------|
 | `tests/utils.test.ts` | 31 | Parameter mappings, normalization, path validation, error responses, version detection |
-| `tests/tool-definitions.test.ts` | 163 | All 155 tools defined, schemas valid, names unique, descriptions < 80 chars |
+| `tests/tool-definitions.test.ts` | 167 | All 157 operations mapped once, 19 public tools, schemas valid |
 | `tests/handlers.test.ts` | 225 | Game command arg transforms, required-param validation, headless op path checks, source structure |
 | `tests/dotnet.test.ts` | 20 | .NET feature flag, .csproj generation, C# script template generation, identifier validation |
 | `tests/validate-script.test.ts` | 12 | GDScript diagnostic parsing + git-changed file collection |
@@ -666,4 +672,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## Credits
 
 - **Original project**: [godot-mcp](https://github.com/Coding-Solo/godot-mcp) by [Solomon Elias (Coding-Solo)](https://github.com/Coding-Solo) - provided the foundational MCP server architecture, headless operations system, and TCP interaction framework
-- **Extended by**: [Tugcan Topaloglu](https://github.com/tugcantopaloglu) - extended to 157 tools covering networking, 3D/2D rendering, UI controls, audio effects, animation trees, file I/O, runtime code execution, node manipulation, signals, project creation, camera control, physics, and comprehensive type conversion
+- **Extended by**: [Tugcan Topaloglu](https://github.com/tugcantopaloglu) - extended to 157 operations covering networking, 3D/2D rendering, UI controls, audio effects, animation trees, file I/O, runtime code execution, node manipulation, signals, project creation, camera control, physics, and comprehensive type conversion

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,27 @@ import {
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
 
+const TOOL_TREE: Record<string, string[]> = {
+  core: ['launch_editor', 'run_project', 'get_debug_output', 'stop_project', 'get_godot_version', 'list_projects', 'get_project_info'],
+  project: ['create_project', 'create_csharp_script', 'read_project_settings', 'modify_project_settings', 'list_project_files', 'manage_autoloads', 'manage_input_map', 'manage_export_presets', 'export_project', 'manage_layers', 'manage_plugins', 'set_main_scene', 'manage_ci_pipeline', 'manage_docker_export'],
+  scene: ['create_scene', 'add_node', 'load_sprite', 'export_mesh_library', 'save_scene', 'get_uid', 'update_project_uids', 'read_scene', 'modify_scene_node', 'remove_scene_node', 'attach_script', 'create_resource', 'manage_scene_signals', 'manage_scene_structure'],
+  filesystem: ['read_file', 'write_file', 'delete_file', 'create_directory', 'rename_file', 'manage_resource', 'create_script', 'manage_shader', 'manage_theme_resource', 'manage_translations'],
+  validation: ['validate_script', 'validate_scripts'],
+  runtime: ['game_screenshot', 'game_click', 'game_key_press', 'game_mouse_move', 'game_get_ui', 'game_get_scene_tree', 'game_eval', 'game_pause', 'game_performance', 'game_wait', 'game_get_errors', 'game_get_logs', 'game_serialize_state', 'game_resource'],
+  node: ['game_get_property', 'game_set_property', 'game_call_method', 'game_get_node_info', 'game_instantiate_scene', 'game_remove_node', 'game_change_scene', 'game_reparent_node', 'game_get_nodes_in_group', 'game_find_nodes_by_class', 'game_spawn_node', 'game_manage_group', 'game_create_timer', 'game_script', 'game_process_mode'],
+  input: ['game_key_hold', 'game_key_release', 'game_scroll', 'game_mouse_drag', 'game_gamepad', 'game_touch', 'game_input_state', 'game_input_action'],
+  signal: ['game_connect_signal', 'game_disconnect_signal', 'game_emit_signal', 'game_list_signals', 'game_await_signal'],
+  animation: ['game_play_animation', 'game_tween_property', 'game_create_animation', 'game_animation_tree', 'game_animation_control', 'game_skeleton_ik', 'game_bone_pose'],
+  camera: ['game_get_camera', 'game_set_camera', 'game_camera_attributes', 'game_viewport'],
+  physics: ['game_raycast', 'game_add_collision', 'game_physics_body', 'game_create_joint', 'game_physics_2d', 'game_physics_3d', 'game_navigation_3d', 'game_navigate_path'],
+  render_2d: ['game_canvas', 'game_canvas_draw', 'game_light_2d', 'game_parallax', 'game_shape_2d', 'game_path_2d', 'game_tilemap', 'game_terrain'],
+  render_3d: ['game_csg', 'game_multimesh', 'game_procedural_mesh', 'game_light_3d', 'game_mesh_instance', 'game_gridmap', 'game_3d_effects', 'game_gi', 'game_path_3d', 'game_sky', 'game_set_shader_param', 'game_set_particles', 'game_environment', 'game_visual_shader', 'game_render_settings', 'game_debug_draw'],
+  audio: ['game_get_audio', 'game_audio_play', 'game_audio_bus', 'game_audio_effect', 'game_audio_bus_layout', 'game_audio_spatial'],
+  ui: ['game_ui_theme', 'game_ui_control', 'game_ui_text', 'game_ui_popup', 'game_ui_tree', 'game_ui_item_list', 'game_ui_tabs', 'game_ui_menu', 'game_ui_range'],
+  network: ['game_http_request', 'game_websocket', 'game_multiplayer', 'game_rpc'],
+  system: ['game_window', 'game_os_info', 'game_time_scale', 'game_world_settings', 'game_locale', 'game_video'],
+};
+
 import {
   PARAMETER_MAPPINGS,
   REVERSE_PARAMETER_MAPPINGS,
@@ -823,10 +844,66 @@ class GodotServer {
   /**
    * Set up the tool handlers for the MCP server
    */
+  private buildGroupedTools(legacyTools: any[]) {
+    return [
+      {
+        name: 'godot_catalog',
+        description: 'Browse the Godot MCP operation tree before choosing a domain tool',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            domain: { type: 'string', enum: Object.keys(TOOL_TREE), description: 'Optional domain to inspect' },
+          },
+        },
+      },
+      ...Object.entries(TOOL_TREE).map(([domain, operations]) => ({
+        name: `${domain}_manage`,
+        description: `Godot ${domain} operations. Call godot_catalog for the operation tree.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            op: { type: 'string', enum: operations, description: `Operation in the ${domain} branch` },
+            params: {
+              type: 'object',
+              description: 'Parameters for the selected operation',
+              additionalProperties: true,
+            },
+          },
+          required: ['op', 'params'],
+        },
+      })),
+    ];
+  }
+
+  private getCatalog(domain?: unknown) {
+    if (domain !== undefined && (typeof domain !== 'string' || !(domain in TOOL_TREE))) {
+      return createErrorResponse(`Unknown domain: ${String(domain)}`);
+    }
+
+    const tree = domain ? { [domain]: TOOL_TREE[domain as string] } : TOOL_TREE;
+    return {
+      content: [{ type: 'text', text: JSON.stringify(tree, null, 2) }],
+    };
+  }
+
+  private resolveGroupedTool(name: string, args: unknown) {
+    const domain = name.endsWith('_manage') ? name.slice(0, -'_manage'.length) : undefined;
+    if (!domain || !(domain in TOOL_TREE)) return undefined;
+
+    const groupedArgs = args as { op?: unknown; params?: unknown } | undefined;
+    if (!groupedArgs || typeof groupedArgs.op !== 'string' || !TOOL_TREE[domain].includes(groupedArgs.op)) {
+      return undefined;
+    }
+    if (groupedArgs.params === undefined || groupedArgs.params === null || typeof groupedArgs.params !== 'object' || Array.isArray(groupedArgs.params)) {
+      return undefined;
+    }
+
+    return { operation: groupedArgs.op, params: groupedArgs.params as Record<string, unknown> };
+  }
+
   private setupToolHandlers() {
-    // Define available tools
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
-      tools: [
+    // Keep each operation's schema internally, but expose a compact domain tree to MCP clients.
+    const legacyTools = [
         {
           name: 'launch_editor',
           description: 'Launch Godot editor for a specific project',
@@ -3304,11 +3381,27 @@ class GodotServer {
             required: ['projectPath', 'action'],
           },
         },
-      ],
+      ];
+
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: this.buildGroupedTools(legacyTools),
     }));
 
     // Handle tool calls
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      if (request.params.name === 'godot_catalog') {
+        return this.getCatalog(request.params.arguments?.domain);
+      }
+
+      const resolved = this.resolveGroupedTool(request.params.name, request.params.arguments);
+      if (!resolved) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          'Use godot_catalog, then call <domain>_manage with a valid op and params object.'
+        );
+      }
+      request.params.name = resolved.operation;
+      request.params.arguments = resolved.params;
       this.logDebug(`Handling tool request: ${request.params.name}`);
       switch (request.params.name) {
         case 'launch_editor':

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,7 @@ class GodotServer {
   private interactionScriptPath: string;
   private validateScriptPath: string;
   private validatedPaths: Map<string, boolean> = new Map();
+  private operationCatalog: Map<string, any> = new Map();
   private strictPathValidation: boolean = false;
   private gameConnection: GameConnection = {
     socket: null,
@@ -880,7 +881,25 @@ class GodotServer {
       return createErrorResponse(`Unknown domain: ${String(domain)}`);
     }
 
-    const tree = domain ? { [domain]: TOOL_TREE[domain as string] } : TOOL_TREE;
+    const tree = domain
+      ? {
+          domain,
+          operations: TOOL_TREE[domain as string].map(operation => {
+            const definition = this.operationCatalog.get(operation);
+            return {
+              name: operation,
+              description: definition?.description,
+              inputSchema: definition?.inputSchema,
+            };
+          }),
+        }
+      : {
+          domains: Object.entries(TOOL_TREE).map(([name, operations]) => ({
+            name,
+            tool: `${name}_manage`,
+            operationCount: operations.length,
+          })),
+        };
     return {
       content: [{ type: 'text', text: JSON.stringify(tree, null, 2) }],
     };
@@ -3382,6 +3401,8 @@ class GodotServer {
           },
         },
       ];
+
+    this.operationCatalog = new Map(legacyTools.map(tool => [tool.name, tool]));
 
     this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
       tools: this.buildGroupedTools(legacyTools),

--- a/tests/tool-definitions.test.ts
+++ b/tests/tool-definitions.test.ts
@@ -130,6 +130,7 @@ describe('Tool definitions', () => {
     expect(sourceCode).toContain("name: 'godot_catalog'");
     expect(sourceCode).toContain('...Object.entries(TOOL_TREE).map');
     expect(sourceCode).toContain('tools: this.buildGroupedTools(legacyTools)');
+    expect(sourceCode).toContain('inputSchema: definition?.inputSchema');
   });
 
   it('no tool description exceeds 80 characters', () => {

--- a/tests/tool-definitions.test.ts
+++ b/tests/tool-definitions.test.ts
@@ -71,7 +71,7 @@ beforeAll(() => {
 });
 
 describe('Tool definitions', () => {
-  it('defines exactly 157 tools', () => {
+  it('keeps exactly 157 internal operations', () => {
     expect(ALL_TOOL_NAMES).toHaveLength(157);
   });
 
@@ -111,6 +111,25 @@ describe('Tool definitions', () => {
     for (const name of ALL_TOOL_NAMES) {
       expect(sourceCode).toContain(`case '${name}':`);
     }
+  });
+
+  it('maps every operation to exactly one branch of the public tool tree', () => {
+    const treeMatch = sourceCode.match(/const TOOL_TREE:[\s\S]*?\n\};/);
+    expect(treeMatch).toBeTruthy();
+
+    const treeOperations = [...treeMatch![0].matchAll(/'([a-z][a-z0-9_]*)'/g)].map(match => match[1]);
+    expect(treeOperations).toHaveLength(ALL_TOOL_NAMES.length);
+    expect(new Set(treeOperations).size).toBe(treeOperations.length);
+    expect([...treeOperations].sort()).toEqual([...ALL_TOOL_NAMES].sort());
+  });
+
+  it('publishes one catalog plus 18 domain tools instead of 157 public tools', () => {
+    const treeMatch = sourceCode.match(/const TOOL_TREE:[\s\S]*?\n\};/);
+    const domains = [...treeMatch![0].matchAll(/^\s{2}([a-z0-9_]+): \[/gm)].map(match => match[1]);
+    expect(domains).toHaveLength(18);
+    expect(sourceCode).toContain("name: 'godot_catalog'");
+    expect(sourceCode).toContain('...Object.entries(TOOL_TREE).map');
+    expect(sourceCode).toContain('tools: this.buildGroupedTools(legacyTools)');
   });
 
   it('no tool description exceeds 80 characters', () => {


### PR DESCRIPTION
## Summary

This PR reduces the MCP server's public tool surface from 157 top-level tools to 19 tree-routed tools while preserving all 157 existing operations and handlers.

The new public surface consists of:

- `godot_catalog` for progressive discovery
- 18 domain tools named `<domain>_manage`

Each domain tool accepts:

```json
{
  "op": "<existing operation name>",
  "params": {
    "...": "existing operation arguments"
  }
}
```

## Motivation

Advertising 157 tools at once creates several practical problems for MCP clients and agents:

- some clients impose limits on the number of exposed tools
- every tool definition consumes model context before any work begins
- a large flat list makes tool selection less reliable
- related Godot capabilities are difficult for an agent to discover as a coherent workflow

This change applies progressive disclosure: agents first choose a domain, inspect only that branch, and then invoke an operation through the matching domain tool.

## Design

### Operation tree

The 157 operations are assigned exactly once across these 18 domains:

- `core`
- `project`
- `scene`
- `filesystem`
- `validation`
- `runtime`
- `node`
- `input`
- `signal`
- `animation`
- `camera`
- `physics`
- `render_2d`
- `render_3d`
- `audio`
- `ui`
- `network`
- `system`

The resulting MCP tool names are `core_manage`, `project_manage`, and so on.

### Progressive schema discovery

Calling `godot_catalog` without a domain returns the available domains, their corresponding MCP tool names, and operation counts.

Calling it with a domain returns only that branch's operations, including each operation's description and original input schema. This keeps the initial tool list compact without making agents guess required parameters.

### Dispatch compatibility

The existing 157 tool definitions remain available internally as the operation catalog. The grouped-call resolver validates the selected domain and operation, unwraps `params`, and forwards the request to the existing switch-based handlers.

No Godot operation handler, GDScript runtime command, TCP interaction behavior, or parameter transformation was rewritten by this PR.

## Migration example

Before:

```text
validate_script({ "projectPath": "C:/games/my-game", "scriptPath": "res://player.gd" })
```

After, call `validation_manage` with:

```json
{
  "op": "validate_script",
  "params": {
    "projectPath": "C:/games/my-game",
    "scriptPath": "res://player.gd"
  }
}
```

## Compatibility impact

This is an intentional breaking change for clients or prompts that invoke the former operation names as top-level MCP tools. The operation names and argument shapes themselves are unchanged; callers route them through the matching `<domain>_manage` tool.

The README now distinguishes public MCP tools from internal operations, documents all branches, and includes migration guidance.

## Validation

- `npm test` — 455 tests passed across 5 test files
- `npm run build` — TypeScript compilation and bundled-script copy completed successfully
- tree coverage verifies all 157 operations are mapped exactly once
- public-surface coverage verifies one catalog plus 18 domain tools
- catalog coverage verifies operation input schemas remain discoverable
- `git diff --check upstream/main...HEAD` — clean

## Files changed

- `src/index.ts` — operation tree, grouped public tools, catalog discovery, and dispatch adapter
- `tests/tool-definitions.test.ts` — operation coverage and compact public-surface assertions
- `README.md` — terminology, tree documentation, migration guidance, and current test totals

## Patch size

- 3 files changed
- 228 insertions
- 67 deletions
