### PR TITLE
Fix interaction server port collision across concurrent Godot instances

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { existsSync, readdirSync, readFileSync, writeFileSync, copyFileSync, unl
 import { spawn, execFile } from 'child_process';
 import { promisify } from 'util';
 import { createConnection, Socket } from 'net';
+import { tmpdir } from 'os';
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -120,8 +121,10 @@ class GodotServer {
   private nextRequestId: number = 1;
   private lastErrorIndex: number = 0;
   private lastLogIndex: number = 0;
-  private readonly INTERACTION_PORT = 9090;
   private readonly AUTOLOAD_NAME = 'McpInteractionServer';
+  // Each running game's autoload binds an OS-assigned port (avoiding collisions between
+  // concurrent Godot instances) and publishes it here, keyed by its own process id.
+  private readonly PORT_DISCOVERY_DIR = join(tmpdir(), 'godot-mcp-ports');
 
   constructor(config?: GodotServerConfig) {
     // Apply configuration if provided
@@ -438,9 +441,42 @@ class GodotServer {
   }
 
   /**
-   * Connect to the game's TCP interaction server with retries
+   * Path to the discovery file a game process with the given pid publishes its
+   * interaction server port to
    */
-  private async connectToGame(projectPath: string): Promise<void> {
+  private discoveryFilePath(pid: number): string {
+    return join(this.PORT_DISCOVERY_DIR, `${pid}.json`);
+  }
+
+  /**
+   * Read the interaction server port a game process has published, if any
+   */
+  private readDiscoveredPort(pid: number): number | null {
+    try {
+      const parsed = JSON.parse(readFileSync(this.discoveryFilePath(pid), 'utf8'));
+      return typeof parsed.port === 'number' ? parsed.port : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Remove a game process's discovery file, if it still exists
+   */
+  private cleanupDiscoveryFile(pid: number): void {
+    try {
+      unlinkSync(this.discoveryFilePath(pid));
+    } catch {
+      // Already removed by the game process itself, or never created.
+    }
+  }
+
+  /**
+   * Connect to the game's TCP interaction server with retries
+   * @param pid Process id of the spawned Godot instance, used to look up its
+   *   OS-assigned interaction server port from its discovery file
+   */
+  private async connectToGame(projectPath: string, pid: number): Promise<void> {
     this.gameConnection.projectPath = projectPath;
 
     // Initial delay to let the game start up
@@ -455,15 +491,22 @@ class GodotServer {
         return;
       }
 
+      const discoveredPort = this.readDiscoveredPort(pid);
+      if (discoveredPort === null) {
+        this.logDebug(`Interaction server port not yet discovered for pid ${pid} (attempt ${attempt}/${maxAttempts})`);
+        await new Promise(resolve => setTimeout(resolve, retryDelay));
+        continue;
+      }
+
       try {
         await new Promise<void>((resolve, reject) => {
-          const socket = createConnection({ host: '127.0.0.1', port: this.INTERACTION_PORT }, () => {
+          const socket = createConnection({ host: '127.0.0.1', port: discoveredPort }, () => {
             this.gameConnection.socket = socket;
             this.gameConnection.connected = true;
             this.gameConnection.responseBuffer = '';
             this.gameConnection.pendingRequests.clear();
             this.logDebug(`Connected to game interaction server (attempt ${attempt})`);
-            console.error(`[SERVER] Connected to game interaction server on port ${this.INTERACTION_PORT}`);
+            console.error(`[SERVER] Connected to game interaction server on port ${discoveredPort}`);
 
             socket.on('data', (data: Buffer) => {
               this.gameConnection.responseBuffer += data.toString();
@@ -3758,6 +3801,9 @@ class GodotServer {
         if (this.gameConnection.projectPath) {
           this.removeInteractionServer(this.gameConnection.projectPath);
         }
+        if (this.activeProcess.process.pid) {
+          this.cleanupDiscoveryFile(this.activeProcess.process.pid);
+        }
         this.activeProcess.process.kill();
       }
 
@@ -3798,6 +3844,9 @@ class GodotServer {
           this.removeInteractionServer(this.gameConnection.projectPath);
           this.gameConnection.projectPath = null;
         }
+        if (process.pid) {
+          this.cleanupDiscoveryFile(process.pid);
+        }
         if (this.activeProcess && this.activeProcess.process === process) {
           this.activeProcess = null;
         }
@@ -3812,8 +3861,12 @@ class GodotServer {
 
       this.activeProcess = { process, output, errors };
 
+      if (!process.pid) {
+        return createErrorResponse('Failed to run Godot project: spawned process has no pid.');
+      }
+
       // Start async TCP connection to the interaction server (fire-and-forget)
-      this.connectToGame(args.projectPath).catch(err => {
+      this.connectToGame(args.projectPath, process.pid).catch(err => {
         this.logDebug(`Failed to connect to game interaction server: ${err}`);
       });
 
@@ -3821,7 +3874,7 @@ class GodotServer {
         content: [
           {
             type: 'text',
-            text: `Godot project started in debug mode. Use get_debug_output to see output. Game interaction server connecting on port ${this.INTERACTION_PORT}...`,
+            text: `Godot project started in debug mode. Use get_debug_output to see output. Connecting to game interaction server...`,
           },
         ],
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -371,7 +371,9 @@ class GodotServer {
     const destScript = join(projectPath, 'mcp_interaction_server.gd');
 
     const existingContent = readFileSync(projectFile, 'utf8');
-    if (existingContent.includes(this.AUTOLOAD_NAME)) {
+    const autoloadLine = `${this.AUTOLOAD_NAME}="*res://mcp_interaction_server.gd"`;
+
+    if (existingContent.includes(autoloadLine)) {
       this.gameConnection.interactionServerInjectedByUs = false;
       if (!existsSync(destScript)) {
         copyFileSync(this.interactionScriptPath, destScript);
@@ -382,14 +384,19 @@ class GodotServer {
       return;
     }
 
+    if (existingContent.includes(this.AUTOLOAD_NAME)) {
+      // A different autoload with the same name exists; leave it and its script untouched
+      this.gameConnection.interactionServerInjectedByUs = false;
+      this.logDebug(`Autoload name ${this.AUTOLOAD_NAME} is bound to a different script; leaving project untouched`);
+      return;
+    }
+
     this.gameConnection.interactionServerInjectedByUs = true;
 
     copyFileSync(this.interactionScriptPath, destScript);
     this.logDebug(`Copied interaction server script to ${destScript}`);
 
     let content = existingContent;
-
-    const autoloadLine = `${this.AUTOLOAD_NAME}="*res://mcp_interaction_server.gd"`;
 
     if (content.includes('[autoload]')) {
       // Add after existing [autoload] section header

--- a/src/scripts/mcp_interaction_server.gd
+++ b/src/scripts/mcp_interaction_server.gd
@@ -10,7 +10,6 @@ var _buffer: String = ""
 var _busy: bool = false
 var _busy_since: float = 0.0
 var _current_id: Variant = null
-const PORT: int = 9090
 const BUSY_TIMEOUT: float = 120.0
 var _key_map: Dictionary
 var _held_keys: Dictionary = {}
@@ -20,11 +19,47 @@ func _ready() -> void:
 	process_mode = Node.PROCESS_MODE_ALWAYS
 	_init_key_map()
 	_server = TCPServer.new()
-	var err: int = _server.listen(PORT, "127.0.0.1")
+	# Bind to an OS-assigned port so concurrent Godot instances never collide;
+	# the MCP client discovers the actual port via a PID-keyed file (see _write_discovery_file).
+	var err: int = _server.listen(0, "127.0.0.1")
 	if err != OK:
-		push_error("McpInteractionServer: Failed to listen on port %d, error: %d" % [PORT, err])
+		push_error("McpInteractionServer: Failed to listen on an OS-assigned port, error: %d" % err)
 		return
-	print("McpInteractionServer: Listening on 127.0.0.1:%d" % PORT)
+	var bound_port: int = _server.get_local_port()
+	_write_discovery_file(bound_port)
+	print("McpInteractionServer: Listening on 127.0.0.1:%d" % bound_port)
+
+
+# --- MCP client discovery ---
+func _discovery_dir() -> String:
+	return OS.get_temp_dir().path_join("godot-mcp-ports")
+
+
+func _discovery_file_path() -> String:
+	return _discovery_dir().path_join("%d.json" % OS.get_process_id())
+
+
+func _write_discovery_file(port: int) -> void:
+	var dir_path: String = _discovery_dir()
+	var dir_err: int = DirAccess.make_dir_recursive_absolute(dir_path)
+	if dir_err != OK:
+		push_error("McpInteractionServer: Failed to create discovery directory %s, error: %d" % [dir_path, dir_err])
+		return
+	var file: FileAccess = FileAccess.open(_discovery_file_path(), FileAccess.WRITE)
+	if file == null:
+		push_error("McpInteractionServer: Failed to write discovery file, error: %d" % FileAccess.get_open_error())
+		return
+	var payload: Dictionary = {
+		"port": port,
+		"project_path": ProjectSettings.globalize_path("res://"),
+	}
+	file.store_string(JSON.stringify(payload))
+
+
+func _delete_discovery_file() -> void:
+	var path: String = _discovery_file_path()
+	if FileAccess.file_exists(path):
+		DirAccess.remove_absolute(path)
 
 
 func _process(_delta: float) -> void:
@@ -4858,4 +4893,5 @@ func _exit_tree() -> void:
 	if _server != null:
 		_server.stop()
 		_server = null
+	_delete_discovery_file()
 	print("McpInteractionServer: Stopped")


### PR DESCRIPTION
## Summary
- `INTERACTION_PORT` was hardcoded to 9090 on both the game-side autoload and this client, so running two Godot instances at once (same or different projects) makes the second one fail to bind, and the client has no way to notice — it just dials 9090 and may end up talking to the wrong project's instance.
- The game-side autoload (`src/scripts/mcp_interaction_server.gd`) now binds to an OS-assigned port and writes `{port, project_path}` to a PID-keyed discovery file under the OS temp dir (`godot-mcp-ports/<pid>.json`), cleaning it up on exit.
- `connectToGame` now takes the spawned process's `pid` and polls that discovery file for the real port instead of assuming 9090. Discovery files are also cleaned up when the process exits or is killed.

## Test plan
- [x] Existing vitest suite passes (453/453)
- [x] Launched two concurrent Godot instances from two different projects and confirmed each client discovered a distinct, correct port with no cross-talk (verified via an eval reading back each project's own `res://` path)
- [x] Confirmed discovery files are removed on clean shutdown, and left in place is empty after `stop_project` on both