### PR TITLE
Fix manage_export_presets list reporting option keys as presets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5447,12 +5447,18 @@ class GodotServer {
           return { content: [{ type: 'text', text: JSON.stringify({ presets: [] }, null, 2) }] };
         const content = readFileSync(presetsFile, 'utf8');
         const presets: Array<{ name: string; platform: string }> = [];
-        const nameMatches = content.matchAll(/name="([^"]+)"/g);
-        const platformMatches = content.matchAll(/platform="([^"]+)"/g);
-        const names = [...nameMatches].map(m => m[1]);
-        const platforms = [...platformMatches].map(m => m[1]);
-        for (let i = 0; i < names.length; i++) {
-          presets.push({ name: names[i], platform: platforms[i] || 'unknown' });
+        // Split on the [preset.N] headers and read each section's own keys.
+        // Matching /name="..."/ across the whole file also catches the option
+        // keys package/name, package/unique_name and version/name, and pairing
+        // two independent match lists then misaligns names with platforms.
+        const sections = content.split(/^\[preset\.\d+\]\s*$/m).slice(1);
+        for (const section of sections) {
+          // Stop at [preset.N.options], whose keys are not the preset's own.
+          const head = section.split(/^\[/m)[0];
+          const name = head.match(/^name="([^"]*)"/m);
+          const platform = head.match(/^platform="([^"]*)"/m);
+          if (!name) continue;
+          presets.push({ name: name[1], platform: platform ? platform[1] : 'unknown' });
         }
         return { content: [{ type: 'text', text: JSON.stringify({ presets }, null, 2) }] };
       } else if (args.action === 'add') {


### PR DESCRIPTION
The `list` action reports every quoted `name="..."` in `export_presets.cfg`, not just the preset names. Godot writes several option keys ending in `name`, so `package/name`, `package/unique_name` and `version/name` are each reported as a preset.

Names and platforms are also gathered into two separate arrays and paired by index. Those counts differ as soon as any option key matches, so the platforms attach to the wrong names.

On a project with three presets (Web, Android, Android Play) the tool reported nine, six of them `"platform": "unknown"`, including values like `"Cat vs Bugs"` and `"1.0"` that are an app title and a version string.

This parses the `[preset.N]` sections and reads each section's own keys, stopping at `[preset.N.options]` so option keys cannot be picked up.

Before:
```json
{"presets": [
  {"name": "Web", "platform": "Web"},
  {"name": "Android", "platform": "Android"},
  {"name": "io.github.lukehmu.catvsbugs", "platform": "Android"},
  {"name": "Cat vs Bugs", "platform": "unknown"},
  {"name": "1.0", "platform": "unknown"},
  {"name": "Android Play", "platform": "unknown"}
]}
```

After:
```json
{"presets": [
  {"name": "Web", "platform": "Web"},
  {"name": "Android", "platform": "Android"},
  {"name": "Android Play", "platform": "Android"}
]}
```

Tested against a Godot 4.7 project with one Web and two Android presets.